### PR TITLE
컴포넌트 개발

### DIFF
--- a/front/app/components/card/ReportCard.tsx
+++ b/front/app/components/card/ReportCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import styled from 'styled-components'
+import PetsIcon from '@mui/icons-material/Pets';
+
+const ReportCard = () => {
+    return (
+        <Wrapper>
+            <p>지난주 산책</p>
+            <Info>
+                <PetsIcon />
+                <Count>
+                    9<p>회</p>
+                </Count>
+            </Info>
+        </Wrapper>
+    )
+}
+
+const Wrapper = styled.div`
+    width: 156px;
+    height: 84px;
+    border: 2px solid ${({ theme }) => theme.colors.black70};
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    p {
+  
+        font-size: 14px;
+        color: ${({ theme }) => theme.colors.black90}
+    }
+`;
+
+const Info = styled.div`
+    display: flex;
+    margin-top: 5px;
+    svg {
+    width: 40px; 
+    height: 40px;
+    fill: purple;    
+  }
+`;
+
+
+const Count = styled.div`
+    font-size: 30px;
+    color: ${({ theme }) => theme.colors.black90};
+    margin-left: 20px;
+    display: flex;
+    align-items: flex-end;
+    p {
+        display: inline-block;
+        font-size: 14px;
+        margin-left: 5px;
+        padding-bottom: 5px;
+     
+    }
+
+`;
+
+export default ReportCard

--- a/front/app/components/card/TodoCard.tsx
+++ b/front/app/components/card/TodoCard.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+interface ITodoCardProps {
+  todoList: {
+    id: number;
+    task: string;
+    mates: {
+      name: string;
+      profileImg: string;
+    }[];
+    createdAt: string;
+    completed: boolean;
+  }[];
+}
+
+
+const TodoCard = ({ todoList }: ITodoCardProps) => {
+  const [todos, setTodos] = useState(todoList);
+
+  const handleCheckboxChange = (id: number) => {
+    const updatedTodos = todos.map((todo) =>
+      todo.id === id ? { ...todo, completed: !todo.completed } : todo
+    );
+    setTodos(updatedTodos);
+  };
+
+  const uncompletedTodos = todos.filter((todo) => !todo.completed);
+  const completedTodos = todos.filter((todo) => todo.completed);
+
+  return (
+    <Wrapper>
+      <TodoListWrapper>
+        <CardTitle>오늘</CardTitle>
+        {uncompletedTodos.map((todo, index) => (
+          <TodoItem key={index}>
+            <Checkbox type='checkbox' onChange={() => handleCheckboxChange(todo.id)} />
+            <TodoText completed={todo.completed}>{todo.task}</TodoText>
+            <MateImgWrapper>
+              {todo.mates.map((mate, mateIndex) => (
+                <MateImg key={mateIndex} index={mateIndex} />
+              ))}
+            </MateImgWrapper>
+          </TodoItem>
+        ))}
+      </TodoListWrapper>
+
+      <TodoListWrapper>
+        <CardTitle>완료</CardTitle>
+        {completedTodos.map((todo, index) => (
+          <TodoItem key={index}>
+            <Checkbox type='checkbox' checked onChange={() => handleCheckboxChange(todo.id)} />
+            <TodoText completed={todo.completed}>{todo.task}</TodoText>
+            <MateImgWrapper>
+              {todo.mates.map((mate, mateIndex) => (
+                <MateImg key={mateIndex} index={mateIndex} />
+              ))}
+            </MateImgWrapper>
+          </TodoItem>
+        ))}
+      </TodoListWrapper>
+      <RegisteredMate></RegisteredMate>
+    </Wrapper>
+  );
+};
+
+
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+`;
+
+const TodoListWrapper = styled.div`
+  width: 349px;
+  background-color: #FFFFFF;
+  margin: 20px;
+  border-radius: 15px;
+  padding-top: 3px;
+  padding-left: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.5);
+  min-height: 70px; 
+`;
+
+
+const TodoItem = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+
+const CardTitle = styled.div`
+  color: ${({ theme }) => theme.colors.black80};
+  font-size: 16px;
+  margin-top: 15px;
+  margin-left: 5px;
+  margin-bottom: 10px;
+`;
+
+const Checkbox = styled.input.attrs<{ checked?: boolean }>(({ checked }) => ({
+  checked: checked || false,
+}))`
+  margin-right: 10px;
+  border: none;
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  appearance: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1.5px solid gainsboro;
+  border-radius: 50%;
+  &:checked {
+    border-color: transparent;
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+    background-size: 100% 100%;
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-color: #06ACF4;
+  }
+  `
+
+
+const TodoText = styled.p<{ completed: boolean }>`
+  font-weight: ${({ theme }) => theme.typo.regular};
+  flex: 1;
+  color: ${({ theme }) => theme.colors.black90};
+  text-decoration: ${({ completed }) => (completed ? 'line-through' : 'none')};
+`;
+
+const MateImgWrapper = styled.div`
+  width: 50px;
+  height: 30px;
+  display: flex;
+  right: 0px;
+  position: relative;
+`;
+
+const MateImg = styled.div<{ index: number }>`
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.colors.black70};
+  position: absolute;
+  left: ${(props) => props.index * 18}px;
+`;
+
+const RegisteredMate = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.black60};
+`;
+
+
+export default TodoCard;

--- a/front/app/components/chart/WalkRank.tsx
+++ b/front/app/components/chart/WalkRank.tsx
@@ -1,9 +1,10 @@
+import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
 
 interface IUser {
-  username: string;
-  profileImg: string;
+  username?: string;
+  profileImg?: string;
   walkCount: number;
 }
 
@@ -17,7 +18,8 @@ const WalkRank = ({ users }: IWalkRank) => {
       {users?.map((user, index) => (
         <BoxWrapper key={index}>
           <UserContainer>
-            <UserProfileImage src={user.profileImg} alt={`${user.username}의 프로필 사진`} />
+            {user.profileImg ? <UserProfileImage><Image src={user.profileImg} alt='프로필 이미지' /></UserProfileImage>
+              : <UserProfileImage />}
             <Nickname>{user.username}</Nickname>
             <WalkCount>{user.walkCount}회</WalkCount>
           </UserContainer>
@@ -27,9 +29,6 @@ const WalkRank = ({ users }: IWalkRank) => {
     </Wrapper>
   );
 };
-
-export default WalkRank;
-
 
 
 const Wrapper = styled.div`
@@ -59,7 +58,7 @@ const Bar = styled.div<{ walkCount: number }>`
   width: 80px;
   height: ${({ walkCount }) => walkCount * 20}px;
   background-color: ${({ theme, walkCount }) => {
-    const maxWalkCount = 18;
+    const maxWalkCount = 13;
     const intensity = walkCount / maxWalkCount;
     const grayShade = Math.round(255 - intensity * 255);
     return `rgb(${grayShade}, ${grayShade}, ${grayShade})`;
@@ -69,21 +68,26 @@ const Bar = styled.div<{ walkCount: number }>`
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-`;
+`
 
 const WalkCount = styled.span`
   font-weight: bold;
-  margin-top: 5px;
+  margin-top: 10px;
   font-weight: ${({ theme }) => theme.typo.medium};
-`;
+`
 
 const Nickname = styled.span`
-  margin-top: 5px;
-`;
+  margin-top: 10px;
+`
 
-const UserProfileImage = styled.img`
+const UserProfileImage = styled.div`
   width: 65px;
   height: 65px;
   border-radius: 50%;
-  margin-top: 10px;
+  margin-top: 10px ;
+  background-color:#CEDBEA;
 `;
+
+export default WalkRank;
+
+

--- a/front/app/components/profile/MateProfile.tsx
+++ b/front/app/components/profile/MateProfile.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+interface MateProfileProps {
+    clickable?: boolean;
+}
+
+const MateProfile = ({ clickable = true }: MateProfileProps) => {
+    const [isProfileClicked, setProfileClicked] = useState(false);
+
+    const onProfileClick = () => {
+        if (clickable) {
+            console.log('메이트 프로필 클릭');
+            setProfileClicked(!isProfileClicked);
+        }
+    };
+
+    return (
+        <Wrapper>
+            <ProfileContainer>
+                <Profile onClick={onProfileClick} isClicked={isProfileClicked} clickable={clickable} />
+            </ProfileContainer>
+            <Info>
+                <NickName>닉네임</NickName>
+                <Name>엄마</Name>
+            </Info>
+        </Wrapper>
+    );
+};
+
+const Wrapper = styled.div`
+  width: 80px;
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ProfileContainer = styled.div`
+  height: 40px;
+`;
+
+const Profile = styled.div<{ isClicked: boolean; clickable: boolean }>`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.colors.light};
+  position: relative;
+  cursor: ${({ clickable }) => (clickable ? 'pointer' : 'default')};
+  box-sizing: border-box;
+  border: ${({ isClicked }) => (isClicked ? '2px solid #06acf4' : 'none')};
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  p {
+    display: inline-block;
+    margin: 3px;
+  }
+`;
+
+const NickName = styled.p`
+  font-size: 14px;
+  color: ${({ theme }) => theme.colors.black90};
+`;
+
+const Name = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.black80};
+`;
+
+export default MateProfile;

--- a/front/app/components/profile/UserProfile.tsx
+++ b/front/app/components/profile/UserProfile.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import CreateOutlinedIcon from '@mui/icons-material/CreateOutlined';
+
+interface IUserProfileProps {
+    user?: {
+        profileImg?: string;
+    };
+}
+
+
+const UserProfile = ({ user }: IUserProfileProps) => {
+
+    const onEditClick = () => {
+        console.log('Edit 클릭!')
+    }
+
+    return (
+        <Wrapper>
+            {user && user.profileImg ? (
+                <>
+                    <Image
+                        src={user.profileImg}
+                        alt="User Profile"
+                        layout="fill"
+                        objectFit="cover"
+                        objectPosition="center"
+                    />
+                    <Edit>
+                        <CreateOutlinedIcon style={{ color: '4A4A4A' }} />
+                    </Edit>
+                </>
+            ) : (
+                <>
+                    <Edit onClick={onEditClick}>
+                        <CreateOutlinedIcon style={{ color: '4A4A4A' }} />
+                    </Edit>
+                </>
+            )}
+        </Wrapper>
+    );
+};
+
+
+
+const Wrapper = styled.div`
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.colors.light};
+    position: relative;
+`;
+
+const Edit = styled.div`
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 40px;
+    height: 40px;
+    background-color: #F5F5F5;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.5);
+    svg {
+        fill: ${({ theme }) => theme.colors.black80}
+    }
+`;
+
+const DefaultImage = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+`;
+
+export default UserProfile;
+
+


### PR DESCRIPTION
## ✅ Changes Made
- 프로필 기본 컴포넌트
- 일정 카드 컴포넌트
- 유저 선택 컴포넌트
- 산책 랭킹

## 🙋🏻‍ Review Point


## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 일정 카드 컴포넌트에 대해서 조금 수정이 필요해 보입니다.. 
사용자가 각 일정을 클릭하면 그 일정에 대한 팝업이 뜨는건데 현재 UI로는 각 일정에 대해 구분선같은 게 없어서 클릭하면 카드 전체를 클릭하는 것 같아 보일 수 있을 것 같아 보입니다. 이에 대해서 아래의 옵션을 생각해봤는데 코멘트 남겨주시면 감사드리겠습니다.

1) 각 일정에 대해 구분선을 넣는다
2) 오늘/완료 카드를 구분하지 않고 일정 각각 카드를 만들어서 체크가 된 일정은 밑으로 내려가게 구성

## 🔗 Reference
Issue #4