### PR TITLE
Design: Calendar 컴포넌트와 global.css 수정

### DIFF
--- a/front/app/components/card/TodoCard.tsx
+++ b/front/app/components/card/TodoCard.tsx
@@ -1,44 +1,40 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { ScheduleItem } from '../schedule/calendar';
+import Image from 'next/image';
 
 interface ITodoCardProps {
-  todoList: {
-    id: number;
-    task: string;
-    mates: {
-      name: string;
-      profileImg: string;
-    }[];
-    createdAt: string;
-    completed: boolean;
-  }[];
+  todoList: ScheduleItem[];
 }
-
 
 const TodoCard = ({ todoList }: ITodoCardProps) => {
   const [todos, setTodos] = useState(todoList);
 
-  const handleCheckboxChange = (id: number) => {
+  const handleCheckboxChange = (scheduleId: number) => {
     const updatedTodos = todos.map((todo) =>
-      todo.id === id ? { ...todo, completed: !todo.completed } : todo
+      todo.scheduleId === scheduleId ? { ...todo, active: !todo.active } : todo
     );
     setTodos(updatedTodos);
   };
 
-  const uncompletedTodos = todos.filter((todo) => !todo.completed);
-  const completedTodos = todos.filter((todo) => todo.completed);
+  const activeTodos = todos.filter((todo) => todo.active);
+  const inactiveTodos = todos.filter((todo) => !todo.active);
 
   return (
     <Wrapper>
       <TodoListWrapper>
         <CardTitle>오늘</CardTitle>
-        {uncompletedTodos.map((todo, index) => (
+        {inactiveTodos.map((todo, index) => (
           <TodoItem key={index}>
-            <Checkbox type='checkbox' onChange={() => handleCheckboxChange(todo.id)} />
-            <TodoText completed={todo.completed}>{todo.task}</TodoText>
+            <Checkbox
+              type='checkbox'
+              checked={!todo.active}
+              onChange={() => handleCheckboxChange(todo.scheduleId)}
+            />
+            <TodoText active={!todo.active}>{todo.scheduleType}</TodoText>
             <MateImgWrapper>
               {todo.mates.map((mate, mateIndex) => (
-                <MateImg key={mateIndex} index={mateIndex} />
+                <MateImg alt='메이트 이미지' key={mateIndex} index={mateIndex} src={mate.user_img} />
               ))}
             </MateImgWrapper>
           </TodoItem>
@@ -47,13 +43,17 @@ const TodoCard = ({ todoList }: ITodoCardProps) => {
 
       <TodoListWrapper>
         <CardTitle>완료</CardTitle>
-        {completedTodos.map((todo, index) => (
+        {activeTodos.map((todo, index) => (
           <TodoItem key={index}>
-            <Checkbox type='checkbox' checked onChange={() => handleCheckboxChange(todo.id)} />
-            <TodoText completed={todo.completed}>{todo.task}</TodoText>
+            <Checkbox
+              type='checkbox'
+              checked
+              onChange={() => handleCheckboxChange(todo.scheduleId)}
+            />
+            <TodoText active={!todo.active}>{todo.scheduleType}</TodoText>
             <MateImgWrapper>
               {todo.mates.map((mate, mateIndex) => (
-                <MateImg key={mateIndex} index={mateIndex} />
+                <MateImg alt='메이트 이미지' key={mateIndex} index={mateIndex} src={mate.user_img} />
               ))}
             </MateImgWrapper>
           </TodoItem>
@@ -89,8 +89,15 @@ const TodoListWrapper = styled.div`
 
 const TodoItem = styled.div`
   display: flex;
+  width: 340px;
+  height: 50px;
+  border-radius: 15px;
   align-items: center;
   margin-bottom: 10px;
+  transition: background-color 0.3s ease; 
+  &:hover {
+    background-color: #f0f0f0; 
+  }
 `;
 
 const CardTitle = styled.div`
@@ -104,7 +111,7 @@ const CardTitle = styled.div`
 const Checkbox = styled.input.attrs<{ checked?: boolean }>(({ checked }) => ({
   checked: checked || false,
 }))`
-  margin-right: 10px;
+  margin: 10px;
   border: none;
   border-radius: 50%;
   width: 25px;
@@ -121,15 +128,14 @@ const Checkbox = styled.input.attrs<{ checked?: boolean }>(({ checked }) => ({
     background-position: 50%;
     background-repeat: no-repeat;
     background-color: #06ACF4;
-  }
-  `
+  }`
 
 
-const TodoText = styled.p<{ completed: boolean }>`
+const TodoText = styled.p<{ active: boolean }>`
   font-weight: ${({ theme }) => theme.typo.regular};
   flex: 1;
   color: ${({ theme }) => theme.colors.black90};
-  text-decoration: ${({ completed }) => (completed ? 'line-through' : 'none')};
+  text-decoration: ${({ active }) => (active ? 'line-through' : 'none')};
 `;
 
 const MateImgWrapper = styled.div`
@@ -140,7 +146,7 @@ const MateImgWrapper = styled.div`
   position: relative;
 `;
 
-const MateImg = styled.div<{ index: number }>`
+const MateImg = styled(Image) <{ index: number }>`
   width: 25px;
   height: 25px;
   border-radius: 50%;

--- a/front/app/components/schedule/calendar.tsx
+++ b/front/app/components/schedule/calendar.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client'
 
 import { getYear, getMonth, getDate, subDays, addDays } from 'date-fns';
 import { useEffect, useState } from 'react';

--- a/front/app/components/schedule/calender.tsx
+++ b/front/app/components/schedule/calender.tsx
@@ -1,0 +1,230 @@
+"use client"
+
+import { getYear, getMonth, getDate, subDays, addDays } from 'date-fns';
+import { useEffect, useState } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import styled from 'styled-components';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import TodoCard from '../card/TodoCard';
+
+export interface ScheduleItem {
+  scheduleId: number;
+  scheduleType: string;
+  mates: {
+    userId: number, user_img: string
+  }[];
+  scheduleDate?: string;
+  reservedDate?: string;
+  time: string;
+  repeatId?: string | null;
+  active: boolean;
+}
+
+export interface ScheduleResponse {
+  schedule: ScheduleItem[];
+}
+
+
+
+const currentYear = getYear(new Date());
+const YEARS = [currentYear - 1, currentYear, currentYear + 1, currentYear + 2];
+const MONTHS = [
+  '1월',
+  '2월',
+  '3월',
+  '4월',
+  '5월',
+  '6월',
+  '7월',
+  '8월',
+  '9월',
+  '10월',
+  '11월',
+  '12월',
+];
+
+
+const Calendar = () => {
+  const [date, setDate] = useState(new Date());
+  const [scheduleData, setScheduleData] = useState<ScheduleResponse | null>(null);
+  const [selectedDateTasks, setSelectedDateTasks] = useState<ScheduleItem[]>([]);
+  const [markedDates, setMarkedDates] = useState<Date[]>([new Date('2023-12-01'), new Date('2023-12-05'), new Date('2023-12-10')]);
+
+  useEffect(() => {
+    const fetchScheduleData = async () => {
+      const year = getYear(date);
+      const month = getMonth(date) + 1;
+
+      try {
+        const response = await fetch(`/api/schedule/month/${year}/${month}`);
+        const data: ScheduleResponse = await response.json();
+        setScheduleData(data);
+        const dateObjects = data.schedule.map((item) => new Date(item.scheduleDate || item.reservedDate || ''));
+        setMarkedDates(dateObjects);
+      } catch (error) {
+        console.error('Month 스케줊 페칭 에러', error);
+      }
+    };
+
+    fetchScheduleData();
+  }, [date]);
+
+  const renderDayContents = (dayOfMonth: number, date?: Date | null): React.ReactNode => {
+    if (!date) return null;
+
+    const formattedDate = date.toISOString().split('T')[0];
+    const isDateMarked = markedDates.some((markedDate) => formattedDate === markedDate.toISOString().split('T')[0]);
+
+    return (
+      <div>
+        {dayOfMonth}
+        {isDateMarked && <Dot />}
+      </div>
+    );
+  };
+
+  const handleDateClick = async (clickedDate: Date) => {
+    try {
+      const formattedDate = clickedDate.toISOString().split('T')[0];
+      const activeScheduleItem = scheduleData?.schedule.find((item) => item.scheduleDate === formattedDate && item.active);
+      const inactiveScheduleItem = scheduleData?.schedule.find((item) => item.reservedDate === formattedDate && !item.active);
+
+      if (activeScheduleItem) {
+        const response = await fetch(`/api/schedule/${activeScheduleItem.scheduleId}`);
+        const data = await response.json();
+        setSelectedDateTasks(data);
+      } else if (inactiveScheduleItem) {
+        setSelectedDateTasks([]);
+      }
+    } catch (error) {
+      console.error('특정 날짜 스케줄 목록 조회 에러', error);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <DatePicker
+        renderDayContents={renderDayContents}
+        selected={date}
+        onChange={(newDate: Date) => {
+          setDate(newDate);
+          handleDateClick(newDate);
+        }}
+        inline
+        dayClassName={(d) => (d.getDate() === date!.getDate() ? 'selectedDay' : 'unselectedDay')}
+        calendarClassName={'calenderWrapper'}
+        closeOnScroll={true}
+        renderCustomHeader={({
+          date,
+          changeYear,
+          decreaseMonth,
+          increaseMonth,
+          prevMonthButtonDisabled,
+          nextMonthButtonDisabled,
+        }) => (
+          <CustomHeaderContainer>
+            <Button type='button' onClick={decreaseMonth} disabled={prevMonthButtonDisabled}>
+              <ChevronLeftIcon />
+            </Button>
+            <div>
+              <select value={getYear(date)} onChange={({ target: { value } }) => changeYear(+value)}>
+                {YEARS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+              <span>{MONTHS[getMonth(date)]}</span>
+            </div>
+
+            <Button type='button' onClick={increaseMonth} disabled={nextMonthButtonDisabled}>
+              <ChevronRightIcon />
+            </Button>
+          </CustomHeaderContainer>
+        )}
+      />
+      <TodoCard todoList={selectedDateTasks} />
+    </Wrapper>
+  );
+};
+
+
+const Wrapper = styled.div` 
+display: flex;
+flex-direction:column;
+  justify-content: center;
+  align-items: center;
+  
+  
+`;
+
+const Dot = styled.div`
+  position: absolute;
+  bottom: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  background-color: #e15f41;
+  border-radius: 50%;
+`;
+
+const CustomHeaderContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #FCFCFC;
+  height: 100%;
+  margin-top: 8px;
+  padding: 5px;
+
+  & > div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    & > * {
+      margin-right: auto;
+      margin-left: auto; 
+    }
+
+    & > span {
+      color: #5b5b5b;
+      font-size: 20px;
+      font-weight: 400;
+    }
+
+    & > select {
+      background-color: #FCFCFC;
+      color: #5b5b5b;
+      border: none;
+      margin-right: 12px;
+      font-size: 20px;
+      font-weight: 400;
+      padding-right: 5px;
+      cursor: pointer;
+    }
+  }
+`;
+
+const Button = styled.button`
+    width: 34px;
+    height: 34px;
+    padding: 5px;
+    border-radius: 50%;
+    svg {
+      color: ${({ theme }) => theme.colors.main};
+    }
+    &:hover {
+      background-color: rgba(#FFFFFF, 0.08);
+    }
+    &:disabled {
+      cursor: default;
+      background-color:  ${({ theme }) => theme.colors.main};
+    }
+`
+
+
+export default Calendar;

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -3,7 +3,88 @@
    License: none (public domain)
 */
 html,
-body,
+body {
+
+	.react-datepicker {
+		border: 1px solid #dcdde1;
+		border-radius: 20px;
+
+		.react-datepicker__day--outside-month {
+
+			cursor: default;
+			visibility: hidden;
+		}
+
+		.calenderWrapper {
+			background-color: #0E0E0E;
+		}
+
+		.react-datepicker__day {
+			position: relative;
+		}
+
+		.selectedDay,
+		.unselectedDay {
+			position: relative;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			color: #4A4A4A;
+			padding: 2px;
+			width: 40px;
+			height: 40px;
+
+
+		}
+
+		.selectedDay {
+			background-color: #FA9E52;
+			border-radius: 30%;
+			color: white;
+
+			&:hover {
+				border-radius: 30%;
+				background-color: #FA9E52;
+			}
+		}
+
+		.unselectedDay {
+			&:hover {
+				border-radius: 30%;
+				background-color: rgba(#FCFCFC, 0.08);
+			}
+		}
+
+		.react-datepicker__header {
+			background-color: #FCFCFC;
+			color: white;
+			border-bottom: none;
+			border-radius: 20px;
+
+			.react-datepicker__day-names {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				margin-top: 5px;
+				height: 30px;
+
+				.react-datepicker__day-name {
+					color: #5b5b5b;
+					margin: 11px;
+				}
+			}
+		}
+
+		.react-datepicker__triangle {
+			display: none;
+		}
+	}
+
+	.calenderWrapper {
+		background-color: #FCFCFC;
+	}
+}
+
 div,
 span,
 applet,
@@ -90,6 +171,7 @@ video {
 	font: inherit;
 	vertical-align: baseline;
 }
+
 /* HTML5 display-role reset for older browsers */
 article,
 aside,
@@ -104,17 +186,21 @@ nav,
 section {
 	display: block;
 }
+
 body {
 	line-height: 1;
 }
+
 ol,
 ul {
 	list-style: none;
 }
+
 blockquote,
 q {
 	quotes: none;
 }
+
 blockquote:before,
 blockquote:after,
 q:before,
@@ -122,6 +208,7 @@ q:after {
 	content: "";
 	content: none;
 }
+
 table {
 	border-collapse: collapse;
 	border-spacing: 0;
@@ -152,7 +239,7 @@ button {
 	border: none;
 	cursor: pointer;
 	background-color: transparent;
-    font-family: 'Pretendard';
+	font-family: 'Pretendard';
 }
 
 textarea {
@@ -164,5 +251,3 @@ textarea {
 textarea:focus {
 	outline: none;
 }
-
-  


### PR DESCRIPTION
## ✅ Changes Made
- 캘린더 컴포넌트와 그에 따른 global.css 수정

## 🙋🏻‍ Review Point
- currentYear에 보시면 현재 날짜 기준으로 전년도, 올해, 내년, 내후년만 나타나게 했습니다. 어제 회의할 때는 내후년까지 보이게 하는 걸로 정했는데 과거 년도는 어디까지 보이게 할지 아직 안정했던 것 같아서 그 부분 의견 주시면 감사하겠습니다~!
- global.css에서는 themeprovider에서 지정한 색을 사용할 수 없는 것 같아 일단은 헥사코드로 지정해 놓았습니다

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> type 파일을 어떻게 관리할지 정하면 좋을 것 같습니다. ex) 같은 폴더 내에 calendarType.d.ts 형식으로 통일 or app dir 내에 type폴더를 따로 만들어서 관리 등
> 

## 🔗 Reference
Issue #20