### PR TITLE
feat: 스케줄 등록 API 및 공통 객체 추가

### DIFF
--- a/.github/workflows/BackEnd-CI.yml
+++ b/.github/workflows/BackEnd-CI.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Formatting with google java
         uses: axel-op/googlejavaformat-action@v3
+        with:
+          version: 1.18.1
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/BackEnd-CI.yml
+++ b/.github/workflows/BackEnd-CI.yml
@@ -32,11 +32,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Formatting with google java
-        uses: axel-op/googlejavaformat-action@v3
-        with:
-          version: 1.18.1
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok:1.18.22'
+    testImplementation 'org.mockito:mockito-inline:3.11.2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/back/src/main/java/com/developaw/harupuppy/HarupuppyApplication.java
+++ b/back/src/main/java/com/developaw/harupuppy/HarupuppyApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class HarupuppyApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(HarupuppyApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(HarupuppyApplication.class, args);
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/activity/domain/Activity.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/activity/domain/Activity.java
@@ -27,30 +27,30 @@ import org.springframework.data.annotation.CreatedDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Activity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  private ScheduleType scheduleType;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ScheduleType scheduleType;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "home_id")
-  private Home home;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_id")
+    private Home home;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-  @Column(name = "created_date")
-  @CreatedDate
-  private LocalDateTime createdDate;
+    @Column(name = "created_date")
+    @CreatedDate
+    private LocalDateTime createdDate;
 
-  @Builder
-  public Activity(ScheduleType scheduleType, Home home, User user) {
-    this.scheduleType = scheduleType;
-    this.home = home;
-    this.user = user;
-  }
+    @Builder
+    public Activity(ScheduleType scheduleType, Home home, User user) {
+        this.scheduleType = scheduleType;
+        this.home = home;
+        this.user = user;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/dog/domain/Dog.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/dog/domain/Dog.java
@@ -1,10 +1,23 @@
 package com.developaw.harupuppy.domain.dog.domain;
 
 import com.developaw.harupuppy.domain.home.domain.Home;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @Getter
@@ -12,35 +25,35 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @NonNull
 public class Dog {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long dogId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long dogId;
 
-  @Column
-  @Size(min = 1, max = 5)
-  private String name;
+    @Column
+    @Size(min = 1, max = 5)
+    private String name;
 
-  @Column(name = "img")
-  private String profilePicture;
+    @Column(name = "img")
+    private String profilePicture;
 
-  @Enumerated(EnumType.STRING)
-  private DogGender gender;
+    @Enumerated(EnumType.STRING)
+    private DogGender gender;
 
-  private LocalDate birthday;
+    private LocalDate birthday;
 
-  private double weight;
+    private double weight;
 
-  @OneToOne
-  @JoinColumn(name = "home_id")
-  private Home home;
+    @OneToOne
+    @JoinColumn(name = "home_id")
+    private Home home;
 
-  @Builder
-  public Dog(
-      String name, String profilePicture, DogGender gender, LocalDate birthday, double weight) {
-    this.name = name;
-    this.profilePicture = profilePicture;
-    this.gender = gender;
-    this.birthday = birthday;
-    this.weight = weight;
-  }
+    @Builder
+    public Dog(
+            String name, String profilePicture, DogGender gender, LocalDate birthday, double weight) {
+        this.name = name;
+        this.profilePicture = profilePicture;
+        this.gender = gender;
+        this.birthday = birthday;
+        this.weight = weight;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/dog/domain/DogGender.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/dog/domain/DogGender.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum DogGender {
-  MALE("남아"),
-  FEMALE("여아");
+    MALE("남아"),
+    FEMALE("여아");
 
-  private final String desc;
+    private final String desc;
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/home/domain/Home.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/home/domain/Home.java
@@ -1,7 +1,13 @@
 package com.developaw.harupuppy.domain.home.domain;
 
 import com.developaw.harupuppy.domain.dog.domain.Dog;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,19 +18,19 @@ import lombok.NoArgsConstructor;
 @Table(name = "HOME")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Home {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "home_id", updatable = false)
-  private Long homeId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "home_id", updatable = false)
+    private Long homeId;
 
-  @Column(name = "home_name")
-  private String homeName;
+    @Column(name = "home_name")
+    private String homeName;
 
-  @OneToOne(mappedBy = "home")
-  private Dog dog;
+    @OneToOne(mappedBy = "home")
+    private Dog dog;
 
-  @Builder
-  public Home(String homeName) {
-    this.homeName = homeName;
-  }
+    @Builder
+    public Home(String homeName) {
+        this.homeName = homeName;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/notification/domain/Notification.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/notification/domain/Notification.java
@@ -26,29 +26,30 @@ import org.springframework.data.annotation.CreatedDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "notification_id")
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
 
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  private NotificationType notificationType;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
 
-  @NotBlank private String message;
+    @NotBlank
+    private String message;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User receiver;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User receiver;
 
-  @Column(name = "send_date")
-  @CreatedDate
-  private LocalDateTime sendDate;
+    @Column(name = "send_date")
+    @CreatedDate
+    private LocalDateTime sendDate;
 
-  @Builder
-  public Notification(NotificationType notificationType, String message, User receiver) {
-    this.notificationType = notificationType;
-    this.message = message;
-    this.receiver = receiver;
-  }
+    @Builder
+    public Notification(NotificationType notificationType, String message, User receiver) {
+        this.notificationType = notificationType;
+        this.message = message;
+        this.receiver = receiver;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/notification/domain/NotificationType.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/notification/domain/NotificationType.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-  SCHEDULE("일정 알림"),
-  SYSTEM("시스템 알림");
-  private final String desc;
+    SCHEDULE("일정 알림"),
+    SYSTEM("시스템 알림");
+    private final String desc;
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/api/ScheduleController.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/api/ScheduleController.java
@@ -4,8 +4,8 @@ import com.developaw.harupuppy.domain.schedule.application.ScheduleService;
 import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
 import com.developaw.harupuppy.global.common.response.ApiResponse;
 import com.developaw.harupuppy.global.common.response.Response.Status;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +19,7 @@ public class ScheduleController {
 
     //TODO :: SpringContextHolder에 저장된 UserDto를 컨트롤러로 가져와 service로 보내기
     @PostMapping
-    public ApiResponse<Void> create(@RequestBody @Valid ScheduleCreateDto dto) {
+    public ApiResponse<Void> create(@RequestBody @Validated ScheduleCreateDto dto) {
         scheduleService.create(dto);
         return ApiResponse.ok(Status.CREATE, null);
     }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/api/ScheduleController.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/api/ScheduleController.java
@@ -1,0 +1,26 @@
+package com.developaw.harupuppy.domain.schedule.api;
+
+import com.developaw.harupuppy.domain.schedule.application.ScheduleService;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.global.common.response.ApiResponse;
+import com.developaw.harupuppy.global.common.response.Response.Status;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+    private final ScheduleService scheduleService;
+
+    //TODO :: SpringContextHolder에 저장된 UserDto를 컨트롤러로 가져와 service로 보내기
+    @PostMapping
+    public ApiResponse<Void> create(@RequestBody @Valid ScheduleCreateDto dto) {
+        scheduleService.create(dto);
+        return ApiResponse.ok(Status.CREATE, null);
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
@@ -1,13 +1,17 @@
 package com.developaw.harupuppy.domain.schedule.application;
 
 import com.developaw.harupuppy.domain.schedule.dao.ScheduleRepository;
+import com.developaw.harupuppy.domain.schedule.dao.UserScheduleRepository;
 import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedule;
 import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
-import com.developaw.harupuppy.domain.user.dto.ScheduleUserDto;
+import com.developaw.harupuppy.domain.user.domain.User;
+import com.developaw.harupuppy.domain.user.dto.UserScheduleDto;
 import com.developaw.harupuppy.domain.user.repository.UserRepository;
 import com.developaw.harupuppy.global.common.exception.CustomException;
 import com.developaw.harupuppy.global.common.response.Response.ErrorCode;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,20 +21,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
+    private final UserScheduleRepository userScheduleRepository;
     private final UserRepository userRepository;
 
     public void create(ScheduleCreateDto dto) {
-        //TODO :: 요청한 유저정보가 서비스에 가입된 유저인지 확인
-        validateMates(dto.mates());
+        List<User> mates = validateMates(dto.mates());
+
         Schedule schedule = ScheduleCreateDto.fromDto(dto);
         scheduleRepository.save(schedule);
+
+        List<UserSchedule> userSchedules = UserSchedule.of(mates, schedule);
+        userSchedules.forEach(schedule::addMate);
+
+        userScheduleRepository.saveAll(userSchedules);
     }
 
-    private void validateMates(List<ScheduleUserDto> mates) {
-        mates.forEach(mate -> {
-            userRepository.findById(mate.userID()).orElseThrow(
-                    () -> new CustomException(ErrorCode.NOT_FOUND_USER)
-            );
-        });
+    private List<User> validateMates(List<UserScheduleDto> mates) {
+        return mates.stream().map(mate -> {
+            User user = userRepository.findById(mate.userID()).orElseThrow(
+                    () -> new CustomException(ErrorCode.NOT_FOUND_USER));
+            return user;
+        }).collect(Collectors.toList());
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
@@ -24,6 +24,7 @@ public class ScheduleService {
     private final UserScheduleRepository userScheduleRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public void create(ScheduleCreateDto dto) {
         List<User> mates = validateMates(dto.mates());
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/application/ScheduleService.java
@@ -1,0 +1,36 @@
+package com.developaw.harupuppy.domain.schedule.application;
+
+import com.developaw.harupuppy.domain.schedule.dao.ScheduleRepository;
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.domain.user.dto.ScheduleUserDto;
+import com.developaw.harupuppy.domain.user.repository.UserRepository;
+import com.developaw.harupuppy.global.common.exception.CustomException;
+import com.developaw.harupuppy.global.common.response.Response.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScheduleService {
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+
+    public void create(ScheduleCreateDto dto) {
+        //TODO :: 요청한 유저정보가 서비스에 가입된 유저인지 확인
+        validateMates(dto.mates());
+        Schedule schedule = ScheduleCreateDto.fromDto(dto);
+        scheduleRepository.save(schedule);
+    }
+
+    private void validateMates(List<ScheduleUserDto> mates) {
+        mates.forEach(mate -> {
+            userRepository.findById(mate.userID()).orElseThrow(
+                    () -> new CustomException(ErrorCode.NOT_FOUND_USER)
+            );
+        });
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dao/ScheduleRepository.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dao/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.developaw.harupuppy.domain.schedule.dao;
+
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dao/UserScheduleRepository.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dao/UserScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.developaw.harupuppy.domain.schedule.dao;
+
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedule;
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedulePK;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserScheduleRepository extends JpaRepository<UserSchedule, UserSchedulePK> {
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/AlertType.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/AlertType.java
@@ -1,16 +1,22 @@
 package com.developaw.harupuppy.domain.schedule.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum AlertType {
-  NONE("없음"),
-  ON_TIME("정각"),
-  FIVE_MINUTES("5분전"),
-  THIRTY_MINUTES("30분전"),
-  ONE_HOUR("1시간전");
+    NONE("없음"),
+    ON_TIME("정각"),
+    FIVE_MINUTES("5분전"),
+    THIRTY_MINUTES("30분전"),
+    ONE_HOUR("1시간전");
 
-  private final String desc;
+    private final String desc;
+
+    @JsonCreator
+    public AlertType fromString(String value) {
+        return AlertType.valueOf(value.toUpperCase());
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/RepeatType.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/RepeatType.java
@@ -1,16 +1,22 @@
 package com.developaw.harupuppy.domain.schedule.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum RepeatType {
-  NONE("없음"),
-  DAT("매일"),
-  WEEK("매주"),
-  MONTH("매월"),
-  YEAR("매년");
+    NONE("없음"),
+    DAT("매일"),
+    WEEK("매주"),
+    MONTH("매월"),
+    YEAR("매년");
 
-  private final String desc;
+    private final String desc;
+
+    @JsonCreator
+    public RepeatType fromString(String value) {
+        return RepeatType.valueOf(value.toUpperCase());
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/Schedule.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/Schedule.java
@@ -10,7 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,56 +24,61 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Schedule extends DateEntity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "schedule_id")
-  private Long id;
+    static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  private ScheduleType scheduleType;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long id;
 
-  @NotNull
-  @Column(name = "reserved_date")
-  private LocalDateTime reservedDate;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ScheduleType scheduleType;
 
-  @Enumerated(EnumType.STRING)
-  private RepeatType repeatType = RepeatType.NONE;
+    @NotNull
+    @Column(name = "reserved_date")
+    private LocalDateTime scheduleDateTime;
 
-  @Enumerated(EnumType.STRING)
-  private AlertType alertType = AlertType.NONE;
+    @Enumerated(EnumType.STRING)
+    private RepeatType repeatType = RepeatType.NONE;
 
-  @Column(columnDefinition = "TEXT")
-  private String memo;
+    @Enumerated(EnumType.STRING)
+    private AlertType alertType = AlertType.NONE;
 
-  @Column(name = "is_deleted")
-  private boolean isDeleted = false;
+    @Column(columnDefinition = "TEXT")
+    private String memo;
 
-  private boolean isActive = true;
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
 
-  @Builder
-  public Schedule(
-      ScheduleType scheduleType,
-      LocalDateTime reservedDate,
-      RepeatType repeatType,
-      AlertType alertType,
-      String memo,
-      boolean isDeleted,
-      boolean isActive) {
-    this.scheduleType = scheduleType;
-    this.reservedDate = reservedDate;
-    this.repeatType = repeatType;
-    this.alertType = alertType;
-    this.memo = memo;
-    this.isDeleted = isDeleted;
-    this.isActive = isActive;
-  }
+    private boolean isActive = true;
 
-  public void done() {
-    isActive = false;
-  }
+    @Builder
+    public Schedule(
+            ScheduleType scheduleType,
+            LocalDateTime scheduleDateTime,
+            RepeatType repeatType,
+            AlertType alertType,
+            String memo) {
+        this.scheduleType = scheduleType;
+        this.scheduleDateTime = scheduleDateTime;
+        this.repeatType = repeatType;
+        this.alertType = alertType;
+        this.memo = memo;
+    }
 
-  public void delete() {
-    isDeleted = true;
-  }
+    public void done() {
+        isActive = false;
+    }
+
+    public void delete() {
+        isDeleted = true;
+    }
+
+    public static LocalDateTime parseDateTime(String date, String time) {
+        LocalDate localDate = LocalDate.parse(date, dateFormatter);
+        LocalTime localTime = LocalTime.parse(time, timeFormatter);
+        return LocalDateTime.of(localDate, localTime);
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/Schedule.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/Schedule.java
@@ -1,19 +1,24 @@
 package com.developaw.harupuppy.domain.schedule.domain;
 
 import com.developaw.harupuppy.global.common.DateEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +45,9 @@ public class Schedule extends DateEntity {
     @Column(name = "reserved_date")
     private LocalDateTime scheduleDateTime;
 
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private List<UserSchedule> mates = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     private RepeatType repeatType = RepeatType.NONE;
 
@@ -58,11 +66,13 @@ public class Schedule extends DateEntity {
     public Schedule(
             ScheduleType scheduleType,
             LocalDateTime scheduleDateTime,
+            List<UserSchedule> mates,
             RepeatType repeatType,
             AlertType alertType,
             String memo) {
         this.scheduleType = scheduleType;
         this.scheduleDateTime = scheduleDateTime;
+        this.mates = mates;
         this.repeatType = repeatType;
         this.alertType = alertType;
         this.memo = memo;
@@ -74,6 +84,11 @@ public class Schedule extends DateEntity {
 
     public void delete() {
         isDeleted = true;
+    }
+
+    public void addMate(UserSchedule mate) {
+        mates.add(mate);
+        mate.getUserSchedulePK().setSchedule(this);
     }
 
     public static LocalDateTime parseDateTime(String date, String time) {

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/ScheduleType.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/ScheduleType.java
@@ -1,20 +1,26 @@
 package com.developaw.harupuppy.domain.schedule.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum ScheduleType {
-  WALK("산책"),
-  WASH("목욕"),
-  POO("응가"),
-  BRUSH("빗질"),
-  FOOD("밥"),
-  GROOM("미용"),
-  HOSPITAL("병원"),
-  WATER("물갈이"),
-  ANNIVERSARY("기념일");
+    WALK("산책"),
+    WASH("목욕"),
+    POO("응가"),
+    BRUSH("빗질"),
+    FOOD("밥"),
+    GROOM("미용"),
+    HOSPITAL("병원"),
+    WATER("물갈이"),
+    ANNIVERSARY("기념일");
 
-  private final String desc;
+    private final String desc;
+
+    @JsonCreator
+    public ScheduleType fromString(String value) {
+        return ScheduleType.valueOf(value.toUpperCase());
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedule.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedule.java
@@ -13,5 +13,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "USER_SCHEDULES")
 public class UserSchedule {
 
-  @EmbeddedId private UserSchedulePK userSchedulePK;
+    @EmbeddedId
+    private UserSchedulePK userSchedulePK;
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedule.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedule.java
@@ -1,8 +1,11 @@
 package com.developaw.harupuppy.domain.schedule.domain;
 
+import com.developaw.harupuppy.domain.user.domain.User;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,4 +18,14 @@ public class UserSchedule {
 
     @EmbeddedId
     private UserSchedulePK userSchedulePK;
+
+    public UserSchedule(UserSchedulePK userSchedulePK) {
+        this.userSchedulePK = userSchedulePK;
+    }
+
+    public static List<UserSchedule> of(List<User> dto, Schedule schedule) {
+        return dto.stream().map(user -> {
+            return new UserSchedule(new UserSchedulePK(user, schedule));
+        }).collect(Collectors.toList());
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedulePK.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedulePK.java
@@ -15,11 +15,11 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 @Getter
 public class UserSchedulePK implements Serializable {
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "schedule_id")
-  private Schedule schedule;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedulePK.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/domain/UserSchedulePK.java
@@ -22,4 +22,13 @@ public class UserSchedulePK implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
+
+    public UserSchedulePK(User user, Schedule schedule) {
+        this.user = user;
+        this.schedule = schedule;
+    }
+
+    public void setSchedule(Schedule schedule) {
+        this.schedule = schedule;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
@@ -1,0 +1,38 @@
+package com.developaw.harupuppy.domain.schedule.dto;
+
+import com.developaw.harupuppy.domain.schedule.domain.AlertType;
+import com.developaw.harupuppy.domain.schedule.domain.RepeatType;
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.domain.ScheduleType;
+import com.developaw.harupuppy.domain.user.dto.ScheduleUserDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
+
+public record ScheduleCreateDto(
+        @NotNull(message = "스케줄 타입 지정이 필요합니다") ScheduleType scheduleType,
+        @NotNull(message = "메이트 지정이 필요합니다") List<ScheduleUserDto> mates,
+        @NotBlank(message = "스케줄 날짜 지정이 필요합니다") String scheduleDate,
+        @NotBlank(message = "스케줄 시간 지정이 필요합니다") String scheduleTime,
+        RepeatType repeatType,
+        AlertType alertType,
+        String memo
+) {
+    public ScheduleCreateDto {
+        Objects.requireNonNull(scheduleType, "스케줄 타입은 필수값 입니다");
+        Objects.requireNonNull(mates, "메이트는 필수값 입니다");
+        Objects.requireNonNull(scheduleDate, "스케줄 날짜는 필수값 입니다");
+        Objects.requireNonNull(scheduleTime, "스케줄 시간은 필수값 입니다");
+    }
+
+    public static Schedule fromDto(ScheduleCreateDto dto) {
+        return Schedule.builder()
+                .scheduleDateTime(Schedule.parseDateTime(dto.scheduleDate(), dto.scheduleTime()))
+                .scheduleType(dto.scheduleType())
+                .alertType(dto.alertType())
+                .repeatType(dto.repeatType())
+                .memo(dto.memo())
+                .build();
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
@@ -4,25 +4,29 @@ import com.developaw.harupuppy.domain.schedule.domain.AlertType;
 import com.developaw.harupuppy.domain.schedule.domain.RepeatType;
 import com.developaw.harupuppy.domain.schedule.domain.Schedule;
 import com.developaw.harupuppy.domain.schedule.domain.ScheduleType;
-import com.developaw.harupuppy.domain.user.dto.ScheduleUserDto;
+import com.developaw.harupuppy.domain.user.dto.UserScheduleDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public record ScheduleCreateDto(
+
         @NotNull(message = "스케줄 타입 지정이 필요합니다") ScheduleType scheduleType,
-        @NotNull(message = "메이트 지정이 필요합니다") List<ScheduleUserDto> mates,
+        @NotNull(message = "메이트 지정이 필요합니다") List<UserScheduleDto> mates,
         @NotBlank(message = "스케줄 날짜 지정이 필요합니다") String scheduleDate,
         @NotBlank(message = "스케줄 시간 지정이 필요합니다") String scheduleTime,
         RepeatType repeatType,
         AlertType alertType,
         String memo
 ) {
+
     public ScheduleCreateDto {
+        validateDateTime(scheduleDate, scheduleTime);
         Objects.requireNonNull(scheduleType, "스케줄 타입은 필수값 입니다");
         Objects.requireNonNull(mates, "메이트는 필수값 입니다");
         Objects.requireNonNull(scheduleDate, "스케줄 날짜는 필수값 입니다");
@@ -30,15 +34,16 @@ public record ScheduleCreateDto(
     }
 
     public static Schedule fromDto(ScheduleCreateDto dto) {
-        validateDateTime(dto.scheduleDate, dto.scheduleTime);
         return Schedule.builder()
                 .scheduleDateTime(Schedule.parseDateTime(dto.scheduleDate(), dto.scheduleTime()))
                 .scheduleType(dto.scheduleType())
+                .mates(new ArrayList<>())
                 .alertType(dto.alertType())
                 .repeatType(dto.repeatType())
                 .memo(dto.memo())
                 .build();
     }
+
     private static void validateDateTime(String date, String time) {
         if (date == null || time == null) {
             throw new IllegalArgumentException("Date and time must not be null");

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
@@ -7,6 +7,9 @@ import com.developaw.harupuppy.domain.schedule.domain.ScheduleType;
 import com.developaw.harupuppy.domain.user.dto.ScheduleUserDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,6 +30,7 @@ public record ScheduleCreateDto(
     }
 
     public static Schedule fromDto(ScheduleCreateDto dto) {
+        validateDateTime(dto.scheduleDate, dto.scheduleTime);
         return Schedule.builder()
                 .scheduleDateTime(Schedule.parseDateTime(dto.scheduleDate(), dto.scheduleTime()))
                 .scheduleType(dto.scheduleType())
@@ -34,5 +38,16 @@ public record ScheduleCreateDto(
                 .repeatType(dto.repeatType())
                 .memo(dto.memo())
                 .build();
+    }
+    private static void validateDateTime(String date, String time) {
+        if (date == null || time == null) {
+            throw new IllegalArgumentException("Date and time must not be null");
+        }
+        try {
+            LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm"));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid date or time format", e);
+        }
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/schedule/dto/ScheduleCreateDto.java
@@ -12,10 +12,8 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public record ScheduleCreateDto(
-
         @NotNull(message = "스케줄 타입 지정이 필요합니다") ScheduleType scheduleType,
         @NotNull(message = "메이트 지정이 필요합니다") List<UserScheduleDto> mates,
         @NotBlank(message = "스케줄 날짜 지정이 필요합니다") String scheduleDate,
@@ -25,15 +23,8 @@ public record ScheduleCreateDto(
         String memo
 ) {
 
-    public ScheduleCreateDto {
-        validateDateTime(scheduleDate, scheduleTime);
-        Objects.requireNonNull(scheduleType, "스케줄 타입은 필수값 입니다");
-        Objects.requireNonNull(mates, "메이트는 필수값 입니다");
-        Objects.requireNonNull(scheduleDate, "스케줄 날짜는 필수값 입니다");
-        Objects.requireNonNull(scheduleTime, "스케줄 시간은 필수값 입니다");
-    }
-
     public static Schedule fromDto(ScheduleCreateDto dto) {
+        validateDateTime(dto.scheduleDate, dto.scheduleTime);
         return Schedule.builder()
                 .scheduleDateTime(Schedule.parseDateTime(dto.scheduleDate(), dto.scheduleTime()))
                 .scheduleType(dto.scheduleType())
@@ -45,14 +36,11 @@ public record ScheduleCreateDto(
     }
 
     private static void validateDateTime(String date, String time) {
-        if (date == null || time == null) {
-            throw new IllegalArgumentException("Date and time must not be null");
-        }
         try {
             LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
             LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm"));
         } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid date or time format", e);
+            throw new IllegalArgumentException("스케줄 날짜와 시간이 유효하지 않습니다", e);
         }
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/domain/User.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/domain/User.java
@@ -2,9 +2,22 @@ package com.developaw.harupuppy.domain.user.domain;
 
 import com.developaw.harupuppy.domain.dog.domain.Dog;
 import com.developaw.harupuppy.domain.home.domain.Home;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @Getter
@@ -12,49 +25,49 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @NonNull
 public class User {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "user_id")
-  private Long userId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
 
-  @Email
-  @Column(unique = true)
-  private String email;
+    @Email
+    @Column(unique = true)
+    private String email;
 
-  @Column(name = "user_img")
-  private String userImg;
+    @Column(name = "user_img")
+    private String userImg;
 
-  private String nickname;
+    private String nickname;
 
-  @Enumerated(EnumType.STRING)
-  @Column(name = "user_role")
-  private UserRole userRole;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role")
+    private UserRole userRole;
 
-  @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
-  private boolean isDeleted;
+    @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
+    private boolean isDeleted;
 
-  @Column(name = "allow_notification", columnDefinition = "TINYINT(1)")
-  private boolean allowNotification;
+    @Column(name = "allow_notification", columnDefinition = "TINYINT(1)")
+    private boolean allowNotification;
 
-  @ManyToOne
-  @JoinColumn(name = "dog_id")
-  private Dog dog;
+    @ManyToOne
+    @JoinColumn(name = "dog_id")
+    private Dog dog;
 
-  @ManyToOne
-  @JoinColumn(name = "home_id")
-  private Home home;
+    @ManyToOne
+    @JoinColumn(name = "home_id")
+    private Home home;
 
-  @Builder
-  public User(String email, String userImg, String nickname, UserRole userRole) {
-    this.email = email;
-    this.userImg = userImg;
-    this.nickname = nickname;
-    this.userRole = userRole;
-    this.isDeleted = false;
-    this.allowNotification = true;
-  }
+    @Builder
+    public User(String email, String userImg, String nickname, UserRole userRole) {
+        this.email = email;
+        this.userImg = userImg;
+        this.nickname = nickname;
+        this.userRole = userRole;
+        this.isDeleted = false;
+        this.allowNotification = true;
+    }
 
-  public void delete() {
-    this.isDeleted = true;
-  }
+    public void delete() {
+        this.isDeleted = true;
+    }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/domain/UserRole.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/domain/UserRole.java
@@ -6,13 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserRole {
-  DAD("아빠"),
-  MOM("엄마"),
-  UNNI("언니"),
-  OPPA("오빠"),
-  NUNA("누나"),
-  HYEONG("형"),
-  YOUNGER("동생");
+    DAD("아빠"),
+    MOM("엄마"),
+    UNNI("언니"),
+    OPPA("오빠"),
+    NUNA("누나"),
+    HYEONG("형"),
+    YOUNGER("동생");
 
-  private final String desc;
+    private final String desc;
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/dto/ScheduleUserDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/dto/ScheduleUserDto.java
@@ -1,0 +1,8 @@
+package com.developaw.harupuppy.domain.user.dto;
+
+import java.util.Objects;
+public record ScheduleUserDto(Long userID) {
+    public ScheduleUserDto {
+        Objects.requireNonNull(userID);
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/dto/UserScheduleDto.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/dto/UserScheduleDto.java
@@ -1,8 +1,9 @@
 package com.developaw.harupuppy.domain.user.dto;
 
 import java.util.Objects;
-public record ScheduleUserDto(Long userID) {
-    public ScheduleUserDto {
+
+public record UserScheduleDto(Long userID) {
+    public UserScheduleDto {
         Objects.requireNonNull(userID);
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/repository/UserRepository.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/repository/UserRepository.java
@@ -3,4 +3,5 @@ package com.developaw.harupuppy.domain.user.repository;
 import com.developaw.harupuppy.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {}
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/back/src/main/java/com/developaw/harupuppy/global/common/DateEntity.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/DateEntity.java
@@ -13,11 +13,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class DateEntity {
-  @CreatedDate
-  @Column(name = "created_date")
-  private LocalDateTime createdDate;
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
 
-  @LastModifiedDate
-  @Column(name = "modified_date")
-  private LocalDateTime modifiedDate;
+    @LastModifiedDate
+    @Column(name = "modified_date")
+    private LocalDateTime modifiedDate;
 }

--- a/back/src/main/java/com/developaw/harupuppy/global/common/exception/CustomException.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/exception/CustomException.java
@@ -4,14 +4,15 @@ import com.developaw.harupuppy.global.common.response.Response.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class CustomException extends RuntimeException{
+public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode){
+    public CustomException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
-    public CustomException(ErrorCode errorCode, String customMessage){
+
+    public CustomException(ErrorCode errorCode, String customMessage) {
         super(customMessage);
         this.errorCode = errorCode;
     }

--- a/back/src/main/java/com/developaw/harupuppy/global/common/exception/CustomException.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/exception/CustomException.java
@@ -1,0 +1,18 @@
+package com.developaw.harupuppy.global.common.exception;
+
+import com.developaw.harupuppy.global.common.response.Response.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    public CustomException(ErrorCode errorCode, String customMessage){
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/global/common/exception/ExceptionControllerAdvice.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,27 @@
+package com.developaw.harupuppy.global.common.exception;
+
+import com.developaw.harupuppy.global.common.response.ApiResponse;
+import com.developaw.harupuppy.global.common.response.Response.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ExceptionControllerAdvice {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customExceptionHandler(CustomException e) {
+        log.error("Error occurs {}", e.toString());
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+                .body(ApiResponse.error(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> runtimeExceptionHandler(RuntimeException e) {
+        log.error("Error occurs {}", e.toString());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/global/common/response/ApiResponse.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/response/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.developaw.harupuppy.global.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> ok(Response.Status status, T data){
+        return new ApiResponse<>(status.getStatus(), status.getMessage(), data);
+    }
+    public static <T> ApiResponse<T> ok(Response.Status status){
+        return new ApiResponse<>(status.getStatus(), status.getMessage(), null);
+    }
+    public static <T> ApiResponse<T> error(Response.ErrorCode errorCode){
+        return new ApiResponse<>(errorCode.getStatus(), errorCode.getMessage(), null);
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
@@ -1,0 +1,27 @@
+package com.developaw.harupuppy.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+public class Response {
+    @Getter
+    @RequiredArgsConstructor
+    public enum ErrorCode{
+        NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
+        ;
+        private final HttpStatus status;
+        private final String message;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Status {
+        UPDATE(HttpStatus.OK, "수정 되었습니다"),
+        CREATE(HttpStatus.CREATED, "생성 되었습니다"),
+        DELETE(HttpStatus.OK, "삭제 되었습니다"),
+        RETRIEVE(HttpStatus.OK, "조회 되었습니다");
+        private final HttpStatus status;
+        private final String message;
+    }
+}

--- a/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
@@ -9,6 +9,7 @@ public class Response {
     @RequiredArgsConstructor
     public enum ErrorCode{
         NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
+        INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러")
         ;
         private final HttpStatus status;
         private final String message;

--- a/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/common/response/Response.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public class Response {
     @Getter
     @RequiredArgsConstructor
-    public enum ErrorCode{
+    public enum ErrorCode {
         NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
         INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러")
         ;

--- a/back/src/main/java/com/developaw/harupuppy/global/configuration/JpaAuditingConfig.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/configuration/JpaAuditingConfig.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfig {}
+public class JpaAuditingConfig {
+}

--- a/back/src/main/resources/application-develop.yml
+++ b/back/src/main/resources/application-develop.yml
@@ -7,6 +7,6 @@ spring:
   jpa:
     database: MYSQL
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/back/src/main/resources/application-test.yml
+++ b/back/src/main/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    hikari.jdbc-url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL
+  jpa:
+    defer-datasource-initialization: true
+    properties:
+      hibernate:
+        dialect=org.hibernate.dialect.H2Dialect
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/back/src/test/java/com/developaw/harupuppy/HarupuppyApplicationTests.java
+++ b/back/src/test/java/com/developaw/harupuppy/HarupuppyApplicationTests.java
@@ -4,6 +4,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class HarupuppyApplicationTests {
-  //  @Test
-  //  void contextLoads() {}
+    //  @Test
+    //  void contextLoads() {}
 }

--- a/back/src/test/java/com/developaw/harupuppy/domain/schedule/api/ScheduleControllerTest.java
+++ b/back/src/test/java/com/developaw/harupuppy/domain/schedule/api/ScheduleControllerTest.java
@@ -1,0 +1,59 @@
+package com.developaw.harupuppy.domain.schedule.api;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.developaw.harupuppy.domain.schedule.application.ScheduleService;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.fixture.ScheduleFixture;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(ScheduleController.class)
+public class ScheduleControllerTest {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("스케줄 생성")
+    void create() throws Exception {
+        ScheduleCreateDto validDto = ScheduleFixture.getCreateDto();
+        mvc.perform(
+                        post("/api/schedules")
+                                .content(objectMapper.writeValueAsString(validDto))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("스케줄 생성 시 필수값이 없어 유효성 검증에서 실패한다")
+    void createWithInvalidDto() throws Exception {
+        ScheduleCreateDto invalidDto = ScheduleFixture.getCreateDtoWithNullType();
+        MvcResult result = mvc.perform(
+                post("/api/schedules")
+                        .content(objectMapper.writeValueAsString(invalidDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        Assertions.assertThat(result.getResolvedException().getMessage().contains("메이트 지정이 필요합니다"));
+    }
+
+}

--- a/back/src/test/java/com/developaw/harupuppy/domain/schedule/application/ScheduleServiceTest.java
+++ b/back/src/test/java/com/developaw/harupuppy/domain/schedule/application/ScheduleServiceTest.java
@@ -1,0 +1,77 @@
+package com.developaw.harupuppy.domain.schedule.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.developaw.harupuppy.domain.schedule.dao.ScheduleRepository;
+import com.developaw.harupuppy.domain.schedule.dao.UserScheduleRepository;
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedule;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.domain.user.domain.User;
+import com.developaw.harupuppy.domain.user.repository.UserRepository;
+import com.developaw.harupuppy.fixture.ScheduleFixture;
+import com.developaw.harupuppy.global.common.exception.CustomException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+    static ScheduleCreateDto createDto;
+    static ScheduleCreateDto invalidDto;
+    static List<User> mates;
+    @InjectMocks
+    private ScheduleService scheduleService;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private UserScheduleRepository userScheduleRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        createDto = ScheduleFixture.getCreateDto();
+        invalidDto = ScheduleFixture.getCreateDtoWithInvalidDateType();
+        mates = ScheduleFixture.getMates();
+    }
+
+    @Test
+    @DisplayName("스케줄 정보를 받아 새로운 스케줄을 생성한다")
+    void create() {
+        Schedule schedule = ScheduleCreateDto.fromDto(createDto);
+        List<UserSchedule> userSchedules = ScheduleFixture.getUserSchedules(mates, schedule);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mates.get(0)));
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mates.get(1)));
+        when(scheduleRepository.save(any())).thenReturn(schedule);
+        when(userScheduleRepository.saveAll(any())).thenReturn(userSchedules);
+
+        scheduleService.create(createDto);
+    }
+    @Test
+    @DisplayName("스케줄 정보의 날짜, 시간 타입이 유효하지 않아 스케줄을 생성할 수 없다")
+    void createWithInvalidDateType(){
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mates.get(0)));
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mates.get(1)));
+        assertThatThrownBy( () -> scheduleService.create(invalidDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스케줄 날짜와 시간이 유효하지 않습니다");
+
+    }
+    @Test
+    @DisplayName("메이트 정보가 존재하지 않아 새로운 스케줄을 저장할 수 없다")
+    void createWithNotFoundUser() {
+        assertThatThrownBy(() -> scheduleService.create(createDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("가입된 유저가 아닙니다");
+    }
+}

--- a/back/src/test/java/com/developaw/harupuppy/domain/schedule/application/ScheduleServiceTest.java
+++ b/back/src/test/java/com/developaw/harupuppy/domain/schedule/application/ScheduleServiceTest.java
@@ -1,5 +1,6 @@
 package com.developaw.harupuppy.domain.schedule.application;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -55,8 +56,7 @@ class ScheduleServiceTest {
         when(scheduleRepository.save(any())).thenReturn(schedule);
         when(userScheduleRepository.saveAll(any())).thenReturn(userSchedules);
 
-        scheduleService.create(createDto);
-    }
+        assertThatNoException().isThrownBy(() -> scheduleService.create(createDto));}
     @Test
     @DisplayName("스케줄 정보의 날짜, 시간 타입이 유효하지 않아 스케줄을 생성할 수 없다")
     void createWithInvalidDateType(){

--- a/back/src/test/java/com/developaw/harupuppy/domain/schedule/dao/ScheduleRepositoryTest.java
+++ b/back/src/test/java/com/developaw/harupuppy/domain/schedule/dao/ScheduleRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.developaw.harupuppy.domain.schedule.dao;
+
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.domain.ScheduleType;
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedule;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.domain.user.domain.User;
+import com.developaw.harupuppy.domain.user.repository.UserRepository;
+import com.developaw.harupuppy.fixture.ScheduleFixture;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class ScheduleRepositoryTest {
+    @Autowired
+    ScheduleRepository scheduleRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserScheduleRepository userScheduleRepository;
+
+    @AfterEach
+    void tearDown() {
+        userScheduleRepository.deleteAllInBatch();
+        scheduleRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void save() {
+        ScheduleCreateDto createDto = ScheduleFixture.getCreateDto();
+        List<User> mates = ScheduleFixture.getMates();
+        userRepository.saveAll(mates);
+
+        Schedule savedSchedule = scheduleRepository.save(ScheduleCreateDto.fromDto(createDto));
+
+        List<UserSchedule> userSchedules = ScheduleFixture.getUserSchedules(mates, savedSchedule);
+        userScheduleRepository.saveAll(userSchedules);
+
+        UserSchedule foundedUserSchedule = userScheduleRepository.findById(userSchedules.get(0).getUserSchedulePK())
+                .orElse(null);
+
+        Assertions.assertEquals(savedSchedule.getScheduleType(), ScheduleType.POO);
+        Assertions.assertNotNull(foundedUserSchedule);
+    }
+
+
+}

--- a/back/src/test/java/com/developaw/harupuppy/fixture/ScheduleFixture.java
+++ b/back/src/test/java/com/developaw/harupuppy/fixture/ScheduleFixture.java
@@ -1,0 +1,70 @@
+package com.developaw.harupuppy.fixture;
+
+import com.developaw.harupuppy.domain.schedule.domain.AlertType;
+import com.developaw.harupuppy.domain.schedule.domain.RepeatType;
+import com.developaw.harupuppy.domain.schedule.domain.Schedule;
+import com.developaw.harupuppy.domain.schedule.domain.ScheduleType;
+import com.developaw.harupuppy.domain.schedule.domain.UserSchedule;
+import com.developaw.harupuppy.domain.schedule.dto.ScheduleCreateDto;
+import com.developaw.harupuppy.domain.user.domain.User;
+import com.developaw.harupuppy.domain.user.domain.UserRole;
+import com.developaw.harupuppy.domain.user.dto.UserScheduleDto;
+import java.util.List;
+
+public class ScheduleFixture {
+    public static ScheduleCreateDto getCreateDto() {
+        return new ScheduleCreateDto(
+                ScheduleType.POO,
+                List.of(new UserScheduleDto(1L), new UserScheduleDto(2L)),
+                "2023-12-25",
+                "12:35",
+                RepeatType.NONE,
+                AlertType.NONE,
+                ""
+        );
+    }
+
+    public static ScheduleCreateDto getCreateDtoWithInvalidDateType() {
+        return new ScheduleCreateDto(
+                ScheduleType.POO,
+                List.of(new UserScheduleDto(1L), new UserScheduleDto(2L)),
+                "0000-00-00",
+                "00:00",
+                RepeatType.NONE,
+                AlertType.NONE,
+                ""
+        );
+    }
+
+    public static ScheduleCreateDto getCreateDtoWithNullType() {
+        return new ScheduleCreateDto(
+                ScheduleType.POO,
+                null,
+                "2023-12-25",
+                "12:35",
+                RepeatType.NONE,
+                AlertType.NONE,
+                ""
+        );
+    }
+
+    public static List<UserSchedule> getUserSchedules(List<User> mates, Schedule schedule) {
+        return UserSchedule.of(mates, schedule);
+    }
+
+    public static List<User> getMates() {
+        return List.of(User.builder()
+                        .email("unni@test.com")
+                        .nickname("언니")
+                        .userImg("src")
+                        .userRole(UserRole.UNNI)
+                        .build(),
+                User.builder()
+                        .email("mom@test.com")
+                        .nickname("엄마")
+                        .userImg("src")
+                        .userRole(UserRole.MOM)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## ✅ Changes Made

- 스케줄 등록 API 구현 및 예외상황 처리 
- 스케줄 등록 API 유닛 테스트 수행
- 공통 예외처리(ControllerAdivice, CustomException, ErrorCode 정의)
- 공통 응답정의(ApiResponse, Resonse 정의)
- **스케줄 등록시 일/주/월/연도 반복설정으로 Schedule, UserSchedule에 내년 말까지 bulk로 insert 되는 부분은 제외되어있습니다**
- 마지막에 포맷팅 적용하면서 다른 파일들까지 추가되니 많아지는것 같네요.. 

## 🙋🏻‍ Review Point

- 코드 컨벤션에서 정의한 응답객체 디자인에 따라 정의 https://www.notion.so/yechanny/Convention-87e656a08bf543bda918ed3ea71afa8c?pvs=4#0844eb839bbe4f40816bd29deaff7897

- 스케줄 등록시 연관된 객체인 UserSchedule에 저장하는 방식이 어떤지? Schedule 저장 할때는 mate정보 없이 저장 -> UserSchedule 저장 후 Schedule에 있는 List<UserSchedule>에 넣어주는 방식으로 처리했는데 다른 방법이 있을지..? 

- 테스트 코드 작성방식이 어떤지..?


## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)
<img width="495" alt="image" src="https://github.com/coding-union-kr/haru-puppy/assets/35358294/e03f481c-d9fd-4509-9a12-0d46021d8c72">

## 🙋🏻‍♀️ Question
> 의논할 사항

@Variel input으로 들어온 날짜, 시간 문자열의 타입 검증을 ScheduleCreateDto의 생성자에 넣어서 생성할때 바로 해주고 싶었는데 
invalid한 테스트 진행 시 api 검증도 전에 잘못된 날짜, 시간값으로 dto를 생성하자마자 오류가 나버리더라고요. 지금은 service에서 fromDto로 Schedule객체 생성 시 날짜 값 검증을 해주고 있습니다. dto 유효성 검증은 controller단에서 해줘야할것 같은데 다른 방법이 있을까요? 아님 이렇게 진행해도 될까요?

@senique-dev 유저 인증 구현 시 필터에서 유저객체를 조회해서 얻은 UserDto를 SpringContextHolder에 넣어주세요. Controller에서 @AuthentificationPriciple로 꺼내서 사용할거고 요청한 유저의 id검증을 서비스단에서 따로 하지 않을 생각입니다.

## 🔗 Reference
Issue #18 