### PR TITLE
fix: TopNav token 없을 때 뒤로가기 버튼 숨기기

### DIFF
--- a/front/app/components/navigation/TopNavigation.tsx
+++ b/front/app/components/navigation/TopNavigation.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components";
 
 const TopNavigation = () => {
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-  const [showNotiButton, setShowNotiButton] = useState(!!token);
+  const [showBtns, setShowBtns] = useState(!!token);
 
   const [hasNotification, setHasNotification] = useState(true);
 
@@ -57,7 +57,7 @@ const TopNavigation = () => {
   }, [pathname]); 
 
   return (
-    <TopNavigationWrap showNoti={showNotiButton}>
+    <TopNavigationWrap showBtns={showBtns}>
         <button onClick={handleGoBack}><ArrowBackRoundedIcon /></button>
         <strong>{currentTitle}</strong>
         <button onClick={handleNotiClick}>{NotiComponent}</button>
@@ -66,7 +66,7 @@ const TopNavigation = () => {
 
 };
 
-const TopNavigationWrap = styled.nav<{ showNoti: boolean }>`
+const TopNavigationWrap = styled.nav<{ showBtns: boolean }>`
     position: fixed;
     top: 0;
     left: 50%;
@@ -86,13 +86,11 @@ const TopNavigationWrap = styled.nav<{ showNoti: boolean }>`
     & > button {
         padding: 12px 15px;
         color: ${({ theme }) => theme.colors.black80};
+        visibility: ${({ showBtns }) => (showBtns ? 'visible' : 'hidden')};
 
         &:hover {
             color: ${({ theme }) => theme.colors.black90};
         }
-    }
-    & > button:last-of-type {
-        visibility: ${({ showNoti }) => (showNoti ? 'visible' : 'hidden')};
     }
 `;
 


### PR DESCRIPTION
## ✅ Changes Made
- TopNav 컴포넌트 token 없을 때는 title만 보이도록 수정. 

## 🙋🏻‍ Review Point
- TopNav가 모든 페이지에서 이제 나오는걸로 수정됐으니까 타이틀이 각 라우트마다 알맞게 나오는지만 확인하면 될 것 같아욥.

## 📸 Screenshot
> 
<img width="312" alt="image" src="https://github.com/coding-union-kr/haru-puppy/assets/87015026/6c78fb80-1c6e-444d-810a-7c5763be03e6">


## 🙋🏻‍♀️ Question
> 

## 🔗 Reference
Issue #42