### PR TITLE
fix: ScheduleAdd 컴포넌트 추가 수정

### DIFF
--- a/front/app/(route)/schedule/components/DateDropdown.tsx
+++ b/front/app/(route)/schedule/components/DateDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import Image from 'next/image';
 import 'react-datepicker/dist/react-datepicker.css';
 import DatePicker from 'react-datepicker';
@@ -27,6 +27,7 @@ interface IDateDropdownProps {
 const DateDropdown = ({ onValueChange, label, isRequired, size }: IDateDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const width = size ? sizeWidthMap[size] : '300px';
 
@@ -36,9 +37,23 @@ const DateDropdown = ({ onValueChange, label, isRequired, size }: IDateDropdownP
     setIsOpen(false);
   };
 
+  const handleClickOutside = (event: MouseEvent) => {
+    if (event.target instanceof Node) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    }
+  };
+
+    useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+    }, []);
 
   return (
-    <DateSelectWrap size={size} width={width}>
+    <DateSelectWrap ref={dropdownRef} size={size} width={width}>
       <label htmlFor='schedule-date'>
         <span><CalendarMonthRoundedIcon /></span>
         {label}

--- a/front/app/(route)/schedule/components/ScheduleAdd.tsx
+++ b/front/app/(route)/schedule/components/ScheduleAdd.tsx
@@ -12,6 +12,8 @@ import ScheduleTypeDropdown from './ScheduleTypeDropdown';
 import MateSelect from './MateSelect';
 import { dummyMatesData } from '@/app/page';
 
+import MemoTextArea from '@/app/components/input/MemoTextArea';
+
 export interface IScheduleAddProps {
     isOpen: boolean;
     onClose?: () => void;
@@ -31,6 +33,7 @@ export interface IFormData {
     time: Date | null;
     repeat: string;
     noti: string;
+    memo: string;
 }
 
 const ScheduleAdd = ({ isOpen, onClose }: IScheduleAddProps) => {
@@ -42,6 +45,7 @@ const ScheduleAdd = ({ isOpen, onClose }: IScheduleAddProps) => {
         time: null,
         repeat: '',
         noti: '',
+        memo: '',
     });
 
     const handleSelectChange = (name: string, value: any) => {
@@ -80,10 +84,11 @@ const ScheduleAdd = ({ isOpen, onClose }: IScheduleAddProps) => {
             <FormWrap>
                 <ScheduleTypeDropdown onValueChange={(value) => handleSelectChange('type', value)} />
                 <MateSelect onValueChange={(value) => handleSelectChange('mates', value)} mates={dummyMatesData} />
-                <DateDropdown onValueChange={(value) => handleSelectChange('date', value)} label={DateDropdownLabel.ScheduleDay} isRequired={true} />
+                <DateDropdown onValueChange={(value) => handleSelectChange('date', value)} dateDropdownType={DateDropdownLabel.ScheduleDay} isRequired={true} />
                 <TimeDropdown onValueChange={(value) => handleSelectChange('time', value)} />
                 <RepeatDropdown onValueChange={(value) => handleSelectChange('repeat', value)} />
                 <NotiDropdown onValueChange={(value) => handleSelectChange('noti', value)} />
+                <MemoTextArea onValueChange={(value) => handleSelectChange('memo', value)}/>
                 <ButtonGroupWrap>
                     <Button onClick={handleSave} width="135px" height="32px">저장</Button>
                     <Button onClick={handleDelete} width="135px" height="32px">삭제</Button>

--- a/front/app/(route)/schedule/components/ScheduleTypeDropdown.tsx
+++ b/front/app/(route)/schedule/components/ScheduleTypeDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useRef, useState, useEffect} from 'react';
+;
 import Image from 'next/image';
 import styled from 'styled-components';
 import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
@@ -28,19 +29,35 @@ interface IScheduleTypeDropdownProps {
 const ScheduleTypeDropdown = ({onValueChange }: IScheduleTypeDropdownProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [selectedValue, setSelectedValue] = useState(options[0]); 
+    const dropdownRef = useRef<HTMLDivElement>(null);
 
-        const handleSelect = (label: string) => {
-            const selectedOption = options.find(option => option.label === label);
-            if (selectedOption) {
-                setSelectedValue(selectedOption); 
-                onValueChange(label);
+    const handleSelect = (label: string) => {
+        const selectedOption = options.find(option => option.label === label);
+        if (selectedOption) {
+            setSelectedValue(selectedOption); 
+            onValueChange(label);
+        }
+        setIsOpen(false); 
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+        if (event.target instanceof Node) {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+            setIsOpen(false);
             }
-            setIsOpen(false); 
+        }
         };
+
+    useEffect(() => {
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, []);
         
       
   return (
-    <ScheduleTypeSelectWrap>
+    <ScheduleTypeSelectWrap ref={dropdownRef}>
       <label htmlFor='schedule-type'>
         <span><TaskAltRoundedIcon/></span>
         활동 유형

--- a/front/app/components/input/MemoTextArea.tsx
+++ b/front/app/components/input/MemoTextArea.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import EditNoteRoundedIcon from '@mui/icons-material/EditNoteRounded';
+
+interface IMemoInputProps {
+    onValueChange: (value: string) => void;
+}
+const MemoTextArea = ({onValueChange} : IMemoInputProps) => {
+    const [textAreaValue, setTextAreaValue] = useState<string>("");
+    const [placeholder, setPlaceholder] = useState('메모를 입력해주세요.');
+
+    const onTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const value = event.target.value;
+        setTextAreaValue(value);
+        setPlaceholder(value !== '' ? '' : '메모를 입력해주세요.');
+    };
+
+    const onBlurHanlder = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+        onValueChange(textAreaValue);
+    }
+
+    return (
+        <InputWrap>
+            <label htmlFor='schedule-memo'>
+            <span><EditNoteRoundedIcon /></span>
+            메모
+            </label>
+           <textarea id='schedule-memo' name='schedule-memo' placeholder={placeholder} minLength={2} maxLength={200} onChange={onTextAreaChange} onBlur={onBlurHanlder}/>
+        </InputWrap>
+      )
+}
+
+const InputWrap = styled.div`
+position: relative; 
+width: 300px;
+display: flex;
+flex-direction: column;
+cursor: pointer;
+
+& > label {
+    font-size: 14px;
+    font-weight: ${({ theme }) => theme.typo.regular};
+    & > span {
+        margin-right: 10px;
+        vertical-align: middle;
+    }
+}
+
+ & textarea {
+    margin-top: 10px;
+    position: relative;
+    width: 298px;
+    min-height: 50px;
+    padding: 15px;
+    border: 1px solid ${({ theme }) => theme.colors.black50};  
+    border-radius: 10px;             
+    color:#000000;
+    font-weight: 400;
+    font-size: 14px;
+    resize: none;
+    &:focus { 
+    border-color: ${({ theme }) => theme.colors.black80};
+   }
+ } 
+`
+
+export default MemoTextArea;

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -70,7 +70,6 @@ body {
 
 				.react-datepicker__day-name {
 					color: #5b5b5b;
-					margin: 11px;
 				}
 			}
 		}


### PR DESCRIPTION
## ✅ Changes Made
- 메모TextArea 컴포넌트 
- 각 드롭다운들 바깥 누르면 닫히도록 수정
- DateDropdown에서 열리는 DatePicker 넘치는 넓이 수정

## 🙋🏻‍ Review Point
- global.css에서 적용된 react-datepicker의 `margin: 11px` 요거 제가 수정해서 push했습니다!
- 메모 TextArea의 maxLength 및 minLength가 적절한지..? 

## 📸 Screenshot
> 

## 🙋🏻‍♀️ Question
> 차후에 함께 고치면 좋겠다고 오늘 이야기한 부분: 
1. react-datepicker 스타일 global.css 말고 각 파일에서 적용하기
2. Input, DateDropDown 등 enum이 쓰이는 부분에서 사이즈, 라벨 등이 다를 때 확장성을 먼저 고려해야할지 아니면 컴포넌트 안에서 처리해주는게 좋을지...? 현재 저희 프로젝트에서는 컴포넌트 안에서 거의다 처리중이지만, 확장성을 우선시했을 때는 어떻게 수정되어야할지? 

## 🔗 Reference
Issue #49 