### PR TITLE
fix: ConainerLayout에서 네비게이션들 삭제 #57

### DIFF
--- a/front/app/components/layout/layout.tsx
+++ b/front/app/components/layout/layout.tsx
@@ -1,21 +1,14 @@
-import { usePathname } from 'next/navigation';
 import styled from 'styled-components';
-import TopNavigation from '../navigation/TopNavigation';
-import BottomNavigation from '../navigation/BottomNavigation';
 
 const ContainerLayout = ({
   children, 
 }: {
   children: React.ReactNode;
 }) => {
-  const pathname = usePathname();
-  const showNavigation = pathname !== '/auth';
 
   return (
     <Container>
-      {showNavigation && <TopNavigation />}
       {children}
-      {showNavigation && <BottomNavigation />}
     </Container>
   );
 };


### PR DESCRIPTION
## ✅ Changes Made
- TopNavigation, Bottomnavigation을 공통으로 넣는 대신 각 페이지별로 다른 레이아웃에 대응하기 위해
ContainerLayout에서 두 컴포넌트를 삭제.

## 🙋🏻‍ Review Point
- TopNavigation을 각 페이지에 넣을 때 token이 없으면 알림, 뒤로가기 버튼이 안 보이고 token이 있으면 보여야합니다.

## 📸 Screenshot
>

## 🙋🏻‍♀️ Question
> 

## 🔗 Reference
Issue #57