### PR TITLE
fix: 카카오 로그인 요청 api 분기 처리 수정

### DIFF
--- a/front/app/(route)/auth/callback/kakao/page.tsx
+++ b/front/app/(route)/auth/callback/kakao/page.tsx
@@ -20,24 +20,24 @@ const Page = () => {
             try {
                 const response = await axios.get(
                     `${BACKEND_REDIRECT_URL}/api/auth/login?code=${code}`,
-                    { withCredentials: true }
                 );
 
                 if (response) {
-                    const accessToken = response.headers['Access-Token'];
-                    const refreshToken = response.headers['Refresh-Token'];
-                    localStorage.setItem(LOCAL_STORAGE_KEYS.ACCESS_TOKEN, accessToken);
-                    localStorage.setItem(LOCAL_STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
-
-                    if (response.status === 200) {
-                        router.push('/');
-                    } else if (response.status === 404) {
+                    if (response.data.isAlreadyRegistered === false) {
+                        // 기존 유저 아닐경우
                         router.push('/auth/welcome');
-                        console.log('404 response: 카카오 정보', response)
-                    }
+                        console.log('user email:', response.data.email)
+                    } else {
+                        // 기존 유저일경우
+                        const accessToken = response.headers['Access-Token'];
+                        const refreshToken = response.headers['Refresh-Token'];
+                        localStorage.setItem(LOCAL_STORAGE_KEYS.ACCESS_TOKEN, accessToken);
+                        localStorage.setItem(LOCAL_STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
 
+                        router.push('/');
+                    }
                 } else {
-                    setError('로그인을 시도하는 중 오류가 발생했습니다.');
+                    setError('응답이 없습니다.');
                 }
             } catch (error) {
                 setError('로그인을 시도하는 중 오류가 발생했습니다.');
@@ -48,6 +48,8 @@ const Page = () => {
             handleLogin();
         }
     }, [code, router]);
+
+
 
     return (
         <Wrapper>

--- a/front/app/(route)/auth/callback/kakao/page.tsx
+++ b/front/app/(route)/auth/callback/kakao/page.tsx
@@ -19,7 +19,7 @@ const Page = () => {
         const handleLogin = async () => {
             try {
                 const response = await axios.get(
-                    `${BACKEND_REDIRECT_URL}/api/auth/login?code=${code}`,
+                    `${BACKEND_REDIRECT_URL}?code=${code}`,
                 );
 
                 if (response) {

--- a/front/app/constants/auth.ts
+++ b/front/app/constants/auth.ts
@@ -11,6 +11,6 @@ const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
 
 export const KAKAO_REDIRECT_URL = "http://localhost:3000/auth/callback/kakao"
 
-export const BACKEND_REDIRECT_URL = "http://localhost:3000/auth/callback/kakao"
+export const BACKEND_REDIRECT_URL = "http://localhost:8080/api/auth/login"
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URL}&response_type=code`;


### PR DESCRIPTION
## ✅ Changes Made
- status값으로 분기처리 했던 코드를 response.data.isAreadyRegistered값의 true/false 유무로 분기처리 해서 라우팅과 토큰을 다르게 처리해주었습니다. 

## 🙋🏻‍ Review Point
- 오늘 백엔드에서 테스트 위해 바로 머지하도록 하겠습니다..!

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 

## 🔗 Reference
Issue #70 