### PR TITLE
feat: 알림 설정용 ToggleSwitch 컴포넌트 작성 및 NavMenu에 children prop 추가 

### DIFF
--- a/front/app/(route)/setting/components/NavMenu.tsx
+++ b/front/app/(route)/setting/components/NavMenu.tsx
@@ -3,22 +3,23 @@ import styled from "styled-components";
 
 interface INavMenu {
     title: string;
-    onClick: () => void;
+    onClick?: () => void;
+    children?: JSX.Element;
 }
 
-const NavMenu = ({title, onClick} : INavMenu) => {
+const NavMenu = ({title, onClick, children} : INavMenu) => {
    return (
     <NavMenuWrap onClick={onClick}>
         <div>
             <strong>{title}</strong>
-            <StyledArrowIcon/>
+            {children || <StyledArrowIcon/>} 
         </div>
     </NavMenuWrap>
    )
 };
 
 const NavMenuWrap = styled.nav`
-width: 324px;
+width: 340px;
 height: 30px;
 border-bottom: 1px solid ${({theme}) => theme.colors.black50};
 
@@ -27,6 +28,7 @@ border-bottom: 1px solid ${({theme}) => theme.colors.black50};
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: center;
     font-size: 16px;
     font-weight: ${({theme}) => theme.typo.regular};
     color: ${({theme}) => theme.colors.black90};

--- a/front/app/components/toggle/ToggleSwitch.tsx
+++ b/front/app/components/toggle/ToggleSwitch.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+interface IToggleSwitchProps {
+    isToggled: boolean;
+    onToggle: (toggled: boolean) => void;
+}
+
+
+const ToggleSwitch = ({isToggled, onToggle} : IToggleSwitchProps) => {
+
+  return (
+    <ToggleContainer onClick={() => onToggle(!isToggled)} isToggled={isToggled}>
+        <ToggleSlider isToggled={isToggled} />
+    </ToggleContainer>
+  );
+};
+
+const ToggleContainer = styled.div<{ isToggled: boolean }>`
+  width: 50px; 
+  height: 25px; 
+  background-color: ${({ isToggled, theme }) => (isToggled ? theme.colors.main: '#ccc')}; 
+  border-radius: 25px;
+  position: relative;
+  cursor: pointer;
+`;
+
+const ToggleSlider = styled.div<{ isToggled: boolean }>`
+  background-color: #fff;
+  height: 20px; 
+  width: 20px; 
+  position: absolute;
+  top: 2px; 
+  left: ${({ isToggled }) => (isToggled ? '26px' : '2px')}; 
+  border-radius: 50%;
+  transition: left 0.2s;
+`;
+
+export default ToggleSwitch;


### PR DESCRIPTION
## ✅ Changes Made
- NavMenu 오른쪽에 아이콘 외 컴포넌트도 넣을 수 있도록 children prop 추가

## 🙋🏻‍ Review Point
- NavMenu 부모컴포넌트에서 사용하실 때는 서로 간격 따로 띄워주셔야합니당
- NavMenu onClick마다 다른 함수로직 달아주셔야합니당 (댓글 참고)

## 📸 Screenshot
> 테스트 예시입니당. 따로 설정 페이지 만들진 않았어요. 
<img width="285" alt="image" src="https://github.com/coding-union-kr/haru-puppy/assets/87015026/2175d935-38a0-4584-9764-96a37e277906">


## 🙋🏻‍♀️ Question
> NavMenu 회원탈퇴와 로그아웃 UI가 단순히 저렇게 화살표 모양이어도 괜찮은지 모르겠어여. 나가는 모양의 아이콘이나 요런걸 달려고 했는데 로그아웃과 회원탈퇴를 구분할만한 아이콘을 못 찾아서 일단 요렇게 뒀습니당. 

## 🔗 Reference
Issue #78