### PR TITLE
fix: CORS 설정 추가 및 OAuth 이메일 파싱 수정

### DIFF
--- a/back/src/main/java/com/developaw/harupuppy/domain/user/api/AuthController.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/api/AuthController.java
@@ -23,6 +23,7 @@ public class AuthController {
     @GetMapping("/login/{provider}")
     public ApiResponse<LoginResponse> login(@PathVariable("provider") String provider,
                                             @RequestParam("code") String code) {
+        log.info("code : {}", code);
         return ApiResponse.ok(Status.CREATE, userFacadeService.login(provider, code));
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/api/AuthController.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/api/AuthController.java
@@ -6,6 +6,7 @@ import com.developaw.harupuppy.global.common.response.ApiResponse;
 import com.developaw.harupuppy.global.common.response.Response.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,13 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 @Slf4j
+@CrossOrigin(origins = "*", exposedHeaders = {"Content-Disposition"})
 public class AuthController {
     private final UserFacadeService userFacadeService;
 
     @GetMapping("/login/{provider}")
     public ApiResponse<LoginResponse> login(@PathVariable("provider") String provider,
                                             @RequestParam("code") String code) {
-        log.info("code : {}", code);
-        return ApiResponse.ok(Status.CREATE, userFacadeService.login(provider, code));
+        LoginResponse response = userFacadeService.login(provider, code);
+        return ApiResponse.ok(Status.CREATE, response);
     }
 }

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
@@ -36,15 +36,9 @@ public class OAuthService {
         log.info("accessToken : {}", oAuthToken.accessToken());
 
         Map<String, Object> userAttributes = getUserInfo(provider, oAuthToken);
-        for (Map.Entry<String, Object> entry : userAttributes.entrySet()) {
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            System.out.println("Key: " + key + ", Value: " + value);
-        }
-
-        String userEmail = (String) userAttributes.get("email");
+        String userEmail = (String)((Map<?, ?>)(userAttributes.get("kakao_account"))).get("email");
         log.info("kakao email : {}", userEmail);
+
         AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
         AtomicReference<UserDetailResponse> registeredUser = new AtomicReference<>(null);
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
@@ -33,11 +33,9 @@ public class OAuthService {
     public OAuthLoginResponse login(String providerName, String code) {
         ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
         OAuthTokenResponse oAuthToken = getAccessToken(provider, code);
-        log.info("accessToken : {}", oAuthToken.accessToken());
 
         Map<String, Object> userAttributes = getUserInfo(provider, oAuthToken);
         String userEmail = (String)((Map<?, ?>)(userAttributes.get("kakao_account"))).get("email");
-        log.info("kakao email : {}", userEmail);
 
         AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
         AtomicReference<UserDetailResponse> registeredUser = new AtomicReference<>(null);
@@ -47,7 +45,6 @@ public class OAuthService {
             isAlreadyRegistered.set(true);
         });
 
-        log.info("null check : {}, {}", isAlreadyRegistered.get(), registeredUser.get());
         return new OAuthLoginResponse(userEmail, isAlreadyRegistered.get(), registeredUser.get());
     }
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
@@ -33,9 +33,11 @@ public class OAuthService {
     public OAuthLoginResponse login(String providerName, String code) {
         ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
         OAuthTokenResponse oAuthToken = getAccessToken(provider, code);
-        Map<String, Object> userAttributes = getUserInfo(provider, oAuthToken);
+        log.info("accessToken : {}", oAuthToken.accessToken());
 
+        Map<String, Object> userAttributes = getUserInfo(provider, oAuthToken);
         String userEmail = (String) userAttributes.get("email");
+        log.info("kakao email : {}", userEmail);
         AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
         AtomicReference<UserDetailResponse> registeredUser = new AtomicReference<>(null);
 
@@ -44,6 +46,7 @@ public class OAuthService {
             isAlreadyRegistered.set(true);
         });
 
+        log.info("null check : {}, {}", isAlreadyRegistered.get(), registeredUser.get());
         return new OAuthLoginResponse(userEmail, isAlreadyRegistered.get(), registeredUser.get());
     }
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
@@ -36,6 +36,13 @@ public class OAuthService {
         log.info("accessToken : {}", oAuthToken.accessToken());
 
         Map<String, Object> userAttributes = getUserInfo(provider, oAuthToken);
+        for (Map.Entry<String, Object> entry : userAttributes.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            System.out.println("Key: " + key + ", Value: " + value);
+        }
+
         String userEmail = (String) userAttributes.get("email");
         log.info("kakao email : {}", userEmail);
         AtomicBoolean isAlreadyRegistered = new AtomicBoolean(false);
@@ -55,9 +62,7 @@ public class OAuthService {
                 .post()
                 .uri(provider.getProviderDetails().getTokenUri())
                 .headers(header -> {
-                    header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
                     header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-                    header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
                     header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
                 })
                 .bodyValue(getTokenRequest(provider, code))
@@ -80,7 +85,7 @@ public class OAuthService {
         return WebClient.create()
                 .get()
                 .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
-                .headers(header -> header.setBearerAuth(String.valueOf(token.accessToken())))
+                .headers(header -> header.setBearerAuth(token.accessToken()))
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
                 })

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/OAuthService.java
@@ -52,6 +52,7 @@ public class OAuthService {
                 .post()
                 .uri(provider.getProviderDetails().getTokenUri())
                 .headers(header -> {
+                    header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
                     header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
                     header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
                     header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/UserFacadeService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/UserFacadeService.java
@@ -34,7 +34,6 @@ public class UserFacadeService {
             TokenDto token = createTokenAndSave(response.registeredUser(), email);
             return new LoginResponse(response, token.accessToken(), token.refreshToken());
         }
-        log.info("email : {}", email);
         return LoginResponse.of(response);
     }
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/application/UserFacadeService.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/application/UserFacadeService.java
@@ -10,12 +10,14 @@ import com.developaw.harupuppy.domain.user.dto.response.UserDetailResponse;
 import com.developaw.harupuppy.global.utils.JwtTokenUtils;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class UserFacadeService {
     @Value("${jwt.refresh-expired-time-ms}")
     private Long refreshExpiredTimeMs;
@@ -32,6 +34,7 @@ public class UserFacadeService {
             TokenDto token = createTokenAndSave(response.registeredUser(), email);
             return new LoginResponse(response, token.accessToken(), token.refreshToken());
         }
+        log.info("email : {}", email);
         return LoginResponse.of(response);
     }
 

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/dto/response/OAuthTokenResponse.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/dto/response/OAuthTokenResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 public record OAuthTokenResponse(
         @JsonProperty("access_token") String accessToken,
-        @JsonProperty("token_type") String tokenType,
-        String scope
+        String scope,
+        @JsonProperty("token_type") String tokenType
 ) {
 }

--- a/back/src/main/java/com/developaw/harupuppy/global/configuration/AuthenticationConfig.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/configuration/AuthenticationConfig.java
@@ -4,6 +4,7 @@ import com.developaw.harupuppy.domain.user.application.UserService;
 import com.developaw.harupuppy.global.configuration.filter.AuthenticationFilter;
 import com.developaw.harupuppy.global.utils.JwtTokenUtils;
 import java.util.Arrays;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -54,12 +56,10 @@ public class AuthenticationConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        config.setAllowedOrigins(Collections.singletonList(CorsConfiguration.ALL));
         config.setAllowedMethods(Arrays.asList("HEAD", "POST", "GET", "PATCH", "DELETE", "PUT", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
-        config.setExposedHeaders(Arrays.asList("Access-Token", "Refresh-Token"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;


### PR DESCRIPTION
## ✅ Changes Made
1. 기존 Spring security 설정에서 Cors Config 빈을 등록해주고, preflight request에서 HttpMethod.OPTIONS로 요청오는 것을 permitAll 해줘서 해결했었지만 다시 같은 CORS 오류가 발생 
-> 가장 우선순위가 높은 설정을 추가하여 해결(AuthController에 @CrossOrigin 설정을 추가)

2. 카카오에서 받아온 이메일 객체의 key가 email이 아닌 kakao_account안에 있는 email이라서 파싱해오는 부분을 수정함 

## 🙋🏻‍ Review Point
> 리뷰어가 확인해야 할 사항 코멘트

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

CORS 에러 상황
![image](https://github.com/coding-union-kr/haru-puppy/assets/35358294/6978ad2a-a1b0-4d61-86d8-eb6c4d66dfea) 
밑의 POST bad request 400에러는 같은 인가코드로 요청을 두번보내고 있어서 프론트에서 reactStrictMode: false 설정을 추가하여 해결했습니다 

## 🙋🏻‍♀️ Question
> 의논할 사항

## 🔗 Reference
Issue #92 