### PR TITLE
refactor: 회원정보수정 로직 변경

### DIFF
--- a/back/src/main/java/com/developaw/harupuppy/domain/user/api/UserController.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/api/UserController.java
@@ -8,8 +8,10 @@ import com.developaw.harupuppy.domain.user.dto.UserUpdateRequest;
 import com.developaw.harupuppy.domain.user.dto.request.HomeCreateRequest;
 import com.developaw.harupuppy.domain.user.dto.request.UserCreateRequest;
 import com.developaw.harupuppy.domain.user.dto.response.UserCreateResponse;
+import com.developaw.harupuppy.domain.user.dto.response.UserDetailResponse;
 import com.developaw.harupuppy.global.common.response.ApiResponse;
 import com.developaw.harupuppy.global.common.response.Response.Status;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -39,8 +41,8 @@ public class UserController {
     }
 
     @PutMapping("/profile")
-    public ApiResponse<UserResponse> updateProfile(@RequestBody @Valid UserUpdateRequest request) {
-        return ApiResponse.ok(Status.UPDATE, userService.updateUserInformation(request));
+    public ApiResponse<UserDetailResponse> updateProfile(@RequestBody @Valid UserUpdateRequest request, HttpServletRequest httpReq) {
+        return ApiResponse.ok(Status.UPDATE, userService.updateUserInformation(request, httpReq));
     }
 
     @PostMapping("/invitation/{homeId}")

--- a/back/src/main/java/com/developaw/harupuppy/domain/user/dto/UserUpdateRequest.java
+++ b/back/src/main/java/com/developaw/harupuppy/domain/user/dto/UserUpdateRequest.java
@@ -5,8 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UserUpdateRequest(
-        @NotNull(message = "유저번호는 필수항목입니다.")
-        Long userId,
         @NotBlank(message = "닉네임을 입력해주세요.")
         String nickname,
         @NotNull(message = "역할을 입력해주세요.")

--- a/back/src/main/java/com/developaw/harupuppy/global/utils/JwtTokenUtils.java
+++ b/back/src/main/java/com/developaw/harupuppy/global/utils/JwtTokenUtils.java
@@ -3,6 +3,7 @@ package com.developaw.harupuppy.global.utils;
 import com.developaw.harupuppy.domain.user.dto.TokenDto;
 import com.developaw.harupuppy.domain.user.dto.response.UserDetailResponse;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
@@ -71,5 +72,12 @@ public class JwtTokenUtils {
                 .setSigningKey(secretKey)
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    private JwsHeader extractHeaders(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getHeader();
     }
 }


### PR DESCRIPTION
## ✅ Changes Made
- 회원정보 수정시 UserUpdateRequest dto에 필드로 들어가있는 userId를 제거하고, token에서 userId값을 받아서 유저 정보를 수정하도록 로직을 변경했습니다.

## 🙋🏻‍ Review Point
- 테스트를 하려면 로그인이 필요할 것 같아서 서버가 돌아가는 것까지만 확인했고, 데이터가 변경되는지는 확인을 못한 상태인데요. 그 부분을 확인해주시면 감사하겠습니다.

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 

## 🔗 Reference
Issue #97