### PR TITLE
feat: 초대받은 유저 회원가입 POST API 요청

### DIFF
--- a/front/app/(route)/auth/login/page.tsx
+++ b/front/app/(route)/auth/login/page.tsx
@@ -1,52 +1,59 @@
-"use client"
-
+'use client';
+import { useRecoilState } from 'recoil';
+import { userState } from '@/app/_states/userState';
 import Image from 'next/image';
-import kakaoMsgIcon from '@/public/svgs/message-circle.svg'
-import styled from "styled-components";
+import kakaoMsgIcon from '@/public/svgs/message-circle.svg';
+import styled from 'styled-components';
 import ContainerLayout from '@/app/components/layout/layout';
-import axios from 'axios'
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { KAKAO_AUTH_URL } from '@/app/constants/api';
+import { useEffect } from 'react';
 
 const LoginPage = () => {
+  const [, setUserData] = useRecoilState(userState);
 
-
-    const router = useRouter();
-    const onLoginClick = () => {
-        router.push(KAKAO_AUTH_URL)
+  useEffect(() => {
+    const params = useSearchParams();
+    const homeId = params?.get('homeId') || null;
+    if (homeId) {
+      setUserData((prevUserData) => ({
+        ...prevUserData,
+        homeId: homeId,
+      }));
     }
+  }, [setUserData]);
 
-    return (
-        <ContainerLayout>
-            <main>
-                <LoginButtonWrap onClick={onLoginClick}>
-                    <Image
-                        priority
-                        src={kakaoMsgIcon}
-                        alt="카카오 메세지"
-                    />
-                    카카오톡 계정으로 시작
-                </LoginButtonWrap>
-            </main>
-        </ContainerLayout>
+  const router = useRouter();
+  const onLoginClick = () => {
+    router.push(KAKAO_AUTH_URL);
+  };
 
-    )
+  return (
+    <ContainerLayout>
+      <main>
+        <LoginButtonWrap onClick={onLoginClick}>
+          <Image priority src={kakaoMsgIcon} alt='카카오 메세지' />
+          카카오톡 계정으로 시작
+        </LoginButtonWrap>
+      </main>
+    </ContainerLayout>
+  );
 };
 
 const LoginButtonWrap = styled.button`
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    width: 322px;
-    height: 44px;
-    border: 1px solid #F2C94C;
-    border-radius: 44px;
-    font-size: 14px;
-    font-weight: ${({ theme }) => theme.typo.regular};
-    color: ${({ theme }) => theme.colors.black80};
-    & > img {
-        margin: 0 59px 0 14px;
-    }
-`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 322px;
+  height: 44px;
+  border: 1px solid #f2c94c;
+  border-radius: 44px;
+  font-size: 14px;
+  font-weight: ${({ theme }) => theme.typo.regular};
+  color: ${({ theme }) => theme.colors.black80};
+  & > img {
+    margin: 0 59px 0 14px;
+  }
+`;
 
 export default LoginPage;

--- a/front/app/(route)/auth/register/user/page.tsx
+++ b/front/app/(route)/auth/register/user/page.tsx
@@ -1,85 +1,114 @@
-"use client"
+'use client';
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/app/_states/userState';
+import { useMutation } from 'react-query';
+import axios from 'axios';
 import ProfileImg, { ProfileType } from '@/app/components/profile/ProfileImg';
-import Input, { InputType } from "@/app/components/input/Input";
-import Button from "@/app/components/button/Button";
-import styled from "styled-components";
+import Input, { InputType } from '@/app/components/input/Input';
+import Button from '@/app/components/button/Button';
+import styled from 'styled-components';
 import ContainerLayout from '@/app/components/layout/layout';
 import TopNavigation from '@/app/components/navigation/TopNavigation';
 import { IUser } from '@/app/_types/user/User';
 import RoleDropdown from '@/app/components/profile/RoleDropdown';
 
-
 const UserRegisterPage = () => {
-    const searchParams = useSearchParams();
-    const [formData, setFormData] = useState<IUser>({
-        imgUrl: 'src://',
-        email: '',
-        password: 'password',
-        nickName: '',
-        userRole: '',
-    });
+  const searchParams = useSearchParams();
 
-    useEffect(() => {
-        const email = searchParams?.get('email');
-        if (email) {
-            setFormData(prevFormData => ({ ...prevFormData, email }));
-        }
-    }, [searchParams]);
+  const userData = useRecoilValue(userState);
+  const isInvitedUser = userData.homeId !== '';
 
-    const [isFormIncomplete, setIsFormIncomplete] = useState(true);
+  const [formData, setFormData] = useState<IUser>({
+    imgUrl: 'src://',
+    email: '',
+    password: 'password',
+    nickName: '',
+    userRole: '',
+  });
 
-    const handleSignupForm = (name: string, value: any) => {
-        const newFormData = { ...formData, [name]: value };
-        setFormData(newFormData);
+  useEffect(() => {
+    const email = searchParams?.get('email');
+    if (email) {
+      setFormData((prevFormData) => ({ ...prevFormData, email }));
+    }
+  }, [searchParams]);
 
-        const formIncomplete = newFormData.nickName === '' || newFormData.userRole === '';
-        setIsFormIncomplete(formIncomplete);
-        console.log(newFormData);
-        console.log(formIncomplete);
+  const [isFormIncomplete, setIsFormIncomplete] = useState(true);
+
+  const handleSignupForm = (name: string, value: any) => {
+    const newFormData = { ...formData, [name]: value };
+    setFormData(newFormData);
+
+    const formIncomplete = newFormData.nickName === '' || newFormData.userRole === '';
+    setIsFormIncomplete(formIncomplete);
+    console.log(newFormData);
+    console.log(formIncomplete);
+  };
+
+  const postApi = (data: any) => {
+    return axios.post(`/api/users/invitation/${userData.homeId}`, data);
+  };
+
+  const mutation = useMutation(postApi, {
+    onSuccess: () => {
+      router.push('/home');
+    },
+    onError: (error) => {
+      console.error('가입 실패:', error);
+    },
+  });
+
+  const router = useRouter();
+  const handleSubmit = () => {
+    const userRequestData = {
+      email: formData.email,
+      password: formData.password,
+      nickName: formData.nickName,
+      imgUrl: formData.imgUrl,
+      userRole: formData.userRole,
+    };
+    const requestData = {
+      user: userRequestData,
+      homeId: userData.homeId,
     };
 
-    const router = useRouter();
-    const handleSubmit = () => {
-        const userRequestData = {
-            email: formData.email,
-            password: formData.password,
-            nickName: formData.nickName,
-            imgUrl: formData.imgUrl,
-            userRole: formData.userRole
-        };
+    if (isInvitedUser) {
+      mutation.mutate(requestData);
+    } else {
+      sessionStorage.setItem('userRequestData', JSON.stringify(userRequestData));
+      router.push('/auth/register/dog');
+    }
+  };
 
-        sessionStorage.setItem('userRequestData', JSON.stringify(userRequestData));
-        router.push('/auth/register/dog');
-    };
-
-    return (
-        <ContainerLayout>
-            <TopNavigation />
-            <UserProfileFormWrap>
-                <ProfileImg profileType={ProfileType.User} onValueChange={(value) => handleSignupForm('imgUrl', value)} />
-                <Input inputType={InputType.NickName} onInputValue={(value) => handleSignupForm('nickName', value)} />
-                <RoleDropdown
-                    onValueChange={(value) => handleSignupForm('userRole', value)} />
-                <Button onClick={handleSubmit} disabled={isFormIncomplete}>저장하기</Button>
-            </UserProfileFormWrap>
-        </ContainerLayout>
-    )
+  return (
+    <ContainerLayout>
+      <TopNavigation />
+      <UserProfileFormWrap>
+        <ProfileImg profileType={ProfileType.User} onValueChange={(value) => handleSignupForm('imgUrl', value)} />
+        <Input inputType={InputType.NickName} onInputValue={(value) => handleSignupForm('nickName', value)} />
+        <RoleDropdown onValueChange={(value) => handleSignupForm('userRole', value)} />
+        <Button onClick={handleSubmit} disabled={isFormIncomplete}>
+          {isInvitedUser ? '가입하기' : '저장하기'}
+        </Button>
+      </UserProfileFormWrap>
+    </ContainerLayout>
+  );
 };
 
 const UserProfileFormWrap = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-top: 100px;
-    & > div{
-        margin-bottom: 45px;
-    }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 100px;
+  & > div {
+    margin-bottom: 45px;
+  }
 
-    & > button {
-        margin-top: 150px;
-    }
-`
+  & > button {
+    margin-top: 150px;
+  }
+`;
 
 export default UserRegisterPage;

--- a/front/app/(route)/invite/page.tsx
+++ b/front/app/(route)/invite/page.tsx
@@ -1,61 +1,72 @@
-"use client"
+'use client';
 
-import Image from 'next/image';
-import kakaoLogo from '../../../public/svgs/kakao_logo.svg'
-import styled from "styled-components";
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/app/_states/userState';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import styled from 'styled-components';
 import ContainerLayout from '@/app/components/layout/layout';
 import TopNavigation from '@/app/components/navigation/TopNavigation';
 
 const InvitePage = () => {
-    const handleShareKakao = () => {
-        window.Kakao.Share.sendCustom({
-            templateId: 102321,
+  const userData = useRecoilValue(userState);
+  const homeId = userData.homeId;
+  console.log(homeId);
+
+  async function shareLink() {
+    const inviteUrl = `http://localhost:3000/auth/login?homeId=${homeId}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: '초대 링크',
+          url: inviteUrl,
         });
+        console.log('초대 성공');
+      } catch (error) {
+        console.error('공유 실패', error);
+      }
+    } else {
+      console.log('이 브라우저는 공유 기능을 지원하지 않습니다');
     }
-    
-   return (
+  }
+
+  return (
     <ContainerLayout>
-        <TopNavigation/>
-        <InvitePageWrap>
-            <strong>강아지를 같이 돌볼 메이트를 초대해주세요!</strong>
-            <InviteButtonWrap onClick={handleShareKakao}>
-            <Image
-                priority
-                src={kakaoLogo}
-                alt="카카오톡"
-                width={20}
-                height={20}
-            />
-            카카오톡으로 공유하기
-            </InviteButtonWrap>
-        </InvitePageWrap>
-    </ContainerLayout> 
-   )
+      <TopNavigation />
+      <InvitePageWrap>
+        <strong>강아지를 같이 돌볼 메이트를 초대해주세요!</strong>
+        <InviteButtonWrap onClick={shareLink}>
+          <ContentCopyIcon width={20} height={20} />
+          초대 링크 복사하기
+        </InviteButtonWrap>
+      </InvitePageWrap>
+    </ContainerLayout>
+  );
 };
 
 const InvitePageWrap = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    & > strong {
-        font-weight: ${({theme}) => theme.typo.semibold};
-    }
-`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  & > strong {
+    font-weight: ${({ theme }) => theme.typo.semibold};
+  }
+`;
 const InviteButtonWrap = styled.button`
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    margin-top: 300px;
-    width: 370px;
-    height: 56px;
-    border-radius: 10px;
-    font-size: 18px;
-    font-weight: ${({theme}) => theme.typo.regular};
-    background-color: #FDDC3F;
-    color: #000000;
-    & > img {
-        margin: 0 28px 0 53px;
-    }
-`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: 300px;
+  width: 370px;
+  height: 56px;
+  border-radius: 10px;
+  font-size: 18px;
+  font-weight: ${({ theme }) => theme.typo.regular};
+  background-color: ${({ theme }) => theme.colors.light};
+  color: #000000;
+  & > :nth-child(1) {
+    margin: 0 28px 0 53px;
+  }
+`;
 
-  export default InvitePage;
+export default InvitePage;

--- a/front/app/_states/userState.ts
+++ b/front/app/_states/userState.ts
@@ -5,8 +5,18 @@ const { persistAtom } = recoilPersist({
   key: 'userState',
   storage: localStorage,
 });
+interface UserStateType {
+  allowNotification: boolean | null;
+  dogId: string;
+  email: string;
+  homeId: string;
+  imgUrl: string | null;
+  nickname: string;
+  userId: string;
+  userRole: string | null;
+}
 
-export const userState = atom({
+export const userState = atom<UserStateType>({
   key: 'userState',
   default: {
     allowNotification: null,


### PR DESCRIPTION
## ✅ Changes Made
- 메이트 초대하기 기능을 navigator.share로 대체하고 homeId 동적으로 담기
- 로그인페이지 쿼리파라미터에 homeId 있을 시 전역 userState에 저장하기
- 유저 회원가입 페이지에서 homeId가 있는지 구분하여 초대유저 회원가입 API 요청
- userState atom에 interface 적용 

## 🙋🏻‍ Review Point
- 로그인페이지 쿼리파라미터에 homeId가 있는지 확인하는 로직을 추가했습니다. 
- 아직 초대유저 회원가입 API 백엔드가 동작하지 않아서 실제 요청은 가지 않습니다. 
- 카카오톡으로 공유하기 버튼 UI도 초대 링크 복사하기 UI로 바꿔뒀어욥. 

## 📸 Screenshot
> ![image](https://github.com/coding-union-kr/haru-puppy/assets/87015026/29e17cbb-b99b-478e-8c76-863c72c240f9)

## 🙋🏻‍♀️ Question
> _types/user/User.ts가 있으니 userState atom에 이를 적용해도 될 것 같져..? 따로 userState atom용 interface를 적용하지 않아도용. 

## 🔗 Reference
Issue #108